### PR TITLE
feat(multiple runners): Add support to handle multiple runners for di…

### DIFF
--- a/clusters/upsert_clusters_types.go
+++ b/clusters/upsert_clusters_types.go
@@ -22,3 +22,8 @@ type UpsertClustersArgsV1 struct {
 type UpsertClustersReplyV1 struct {
 	Done bool
 }
+
+type UpsertClustersArgsV2 struct {
+	types.AuthArgsV2
+	Clusters []UpsertClusterDtoV1
+}

--- a/enums/os_enums/types.go
+++ b/enums/os_enums/types.go
@@ -1,0 +1,18 @@
+package os_enums
+
+type Type uint
+
+const (
+	LINUX Type = iota + 1
+	WINDOWS
+	MaxType //always add new types before MaxType
+)
+
+var typesToString = map[Type]string{
+	LINUX:   "linux",
+	WINDOWS: "windows",
+}
+
+func (t Type) String() string {
+	return typesToString[t]
+}

--- a/enums/parameters_enums/keys.go
+++ b/enums/parameters_enums/keys.go
@@ -56,19 +56,19 @@ const (
 	EcsServiceArn           Key = 44
 	TaskDefinitionArn       Key = 45
 	InstallationId          Key = 46
-	CpuArchitecture         Key = 47
-	ResponseHeaders         Key = 48
-	Domains                 Key = 49
-	RedirectDomain          Key = 50
-	AcmCertificateArn       Key = 51
-	CertificateRegion       Key = 52
-	CertificateDomain       Key = 53
-	CertificateID           Key = 54
-	ParentDomain            Key = 55
-	CreateMultipleNats      Key = 56
-	ErrorPages              Key = 57
-	PreviewID               Key = 58
-	IsPreview               Key = 59
+	//CpuArchitecture         Key = 47
+	ResponseHeaders    Key = 48
+	Domains            Key = 49
+	RedirectDomain     Key = 50
+	AcmCertificateArn  Key = 51
+	CertificateRegion  Key = 52
+	CertificateDomain  Key = 53
+	CertificateID      Key = 54
+	ParentDomain       Key = 55
+	CreateMultipleNats Key = 56
+	ErrorPages         Key = 57
+	PreviewID          Key = 58
+	IsPreview          Key = 59
 )
 
 var keyToString = map[Key]string{
@@ -118,19 +118,19 @@ var keyToString = map[Key]string{
 	EcsServiceArn:           "ecs service arn",
 	TaskDefinitionArn:       "task definition arn",
 	InstallationId:          "installation id",
-	CpuArchitecture:         "cpu architecture",
-	ResponseHeaders:         "response headers",
-	Domains:                 "domains",
-	RedirectDomain:          "redirect domain",
-	AcmCertificateArn:       "ACM certificate Arn",
-	CertificateRegion:       "Certificate region",
-	CertificateDomain:       "Certificate domain",
-	CertificateID:           "Certificate ID",
-	ParentDomain:            "Parent domain",
-	CreateMultipleNats:      "Create multiple nats",
-	ErrorPages:              "error pages",
-	PreviewID:               "Preview ID",
-	IsPreview:               "Is the job of type preview",
+	//CpuArchitecture:         "cpu architecture",
+	ResponseHeaders:    "response headers",
+	Domains:            "domains",
+	RedirectDomain:     "redirect domain",
+	AcmCertificateArn:  "ACM certificate Arn",
+	CertificateRegion:  "Certificate region",
+	CertificateDomain:  "Certificate domain",
+	CertificateID:      "Certificate ID",
+	ParentDomain:       "Parent domain",
+	CreateMultipleNats: "Create multiple nats",
+	ErrorPages:         "error pages",
+	PreviewID:          "Preview ID",
+	IsPreview:          "Is the job of type preview",
 }
 
 func (k Key) String() string {
@@ -188,19 +188,19 @@ var keyMap = map[Key]string{
 	EcsServiceArn:           "44",
 	TaskDefinitionArn:       "45",
 	InstallationId:          "46",
-	CpuArchitecture:         "47",
-	ResponseHeaders:         "48", //[][]string/primitive.A
-	Domains:                 "49", //[]string/primitive.A
-	RedirectDomain:          "50", //[]string/primitive.A - 0th element is from and 1st element is to
-	AcmCertificateArn:       "51",
-	CertificateRegion:       "52",
-	CertificateDomain:       "53",
-	CertificateID:           "54",
-	ParentDomain:            "55",
-	CreateMultipleNats:      "56",
-	ErrorPages:              "57", //[][]string/primitive.A
-	PreviewID:               "58",
-	IsPreview:               "59",
+	//CpuArchitecture:         "47",
+	ResponseHeaders:    "48", //[][]string/primitive.A
+	Domains:            "49", //[]string/primitive.A
+	RedirectDomain:     "50", //[]string/primitive.A - 0th element is from and 1st element is to
+	AcmCertificateArn:  "51",
+	CertificateRegion:  "52",
+	CertificateDomain:  "53",
+	CertificateID:      "54",
+	ParentDomain:       "55",
+	CreateMultipleNats: "56",
+	ErrorPages:         "57", //[][]string/primitive.A
+	PreviewID:          "58",
+	IsPreview:          "59",
 }
 
 func (k Key) Key() (string, error) {

--- a/enums/region_enums/types.go
+++ b/enums/region_enums/types.go
@@ -1,5 +1,7 @@
 package region_enums
 
+import "fmt"
+
 type Type uint
 
 const (
@@ -65,4 +67,42 @@ var TypeToString = map[Type]string{
 
 func (a Type) String() string {
 	return TypeToString[a]
+}
+
+var StringToType = map[string]Type{
+	"eu-west-1":      EuWest1,
+	"ap-south-1":     ApSouth1,
+	"ap-northeast-1": ApNorthEast1,
+	"ap-northeast-2": ApNorthEast2,
+	"ap-northeast-3": ApNorthEast3,
+	"ap-southeast-1": ApSouthEast1,
+	"ap-southeast-2": ApSouthEast2,
+	"ca-central-1":   CaCentral1,
+	"eu-central-1":   EuCentral1,
+	"eu-north-1":     EuNorth1,
+	"eu-west-2":      EuWest2,
+	"eu-west-3":      EuWest3,
+	"sa-east-1":      SaEast1,
+	"us-east-1":      UsEast1,
+	"us-east-2":      UsEast2,
+	"us-west-1":      UsWest1,
+	"us-west-2":      UsWest2,
+	"af-south-1":     AfSouth1,
+	"ap-east-1":      ApEast1,
+	"ap-south-2":     ApSouth2,
+	"ap-southeast-3": ApSouthEast3,
+	"ap-southeast-4": ApSouthEast4,
+	"eu-central-2":   EuCentral2,
+	"eu-south-1":     EuSouth1,
+	"eu-south-2":     EuSouth2,
+	"me-central-1":   MeCentral1,
+	"me-south-1":     MeSouth1,
+}
+
+func GetType(s string) (Type, error) {
+	t, ok := StringToType[s]
+	if !ok {
+		return 0, fmt.Errorf("error finding type for string: %s", s)
+	}
+	return t, nil
 }

--- a/jobs/jobs_count_types.go
+++ b/jobs/jobs_count_types.go
@@ -10,3 +10,7 @@ type JobsCountDtoV1 struct {
 	Count                  int
 	RunnerOnTimeoutSeconds int
 }
+
+type JobsCountArgsV2 struct {
+	types.AuthArgsV2
+}

--- a/jobs/pending_jobs_types.go
+++ b/jobs/pending_jobs_types.go
@@ -21,3 +21,7 @@ type PendingJobDtoV1 struct {
 type PendingJobsDtoV1 struct {
 	Jobs []PendingJobDtoV1
 }
+
+type PendingJobsArgsV2 struct {
+	types.AuthArgsV2
+}

--- a/ping/types.go
+++ b/ping/types.go
@@ -15,3 +15,17 @@ type ReplyV1 struct {
 	UpgradeFromTs      int64
 	UpgradeToTs        int64
 }
+
+type ArgsV2 struct {
+	types.AuthArgsV2
+	Send      string
+	FirstPing bool
+}
+
+type ReplyV2 struct {
+	Send                         string
+	RunnerUpgradeDockerImage     string
+	ControllerUpgradeDockerImage string
+	UpgradeFromTs                int64
+	UpgradeToTs                  int64
+}

--- a/types/types.go
+++ b/types/types.go
@@ -11,3 +11,13 @@ type AuthArgsV1 struct {
 	Token          string
 	DockerImage    string
 }
+
+type AuthArgsV2 struct {
+	OrganizationID string
+	Token          string
+	DockerImage    string
+	CloudAccountID string
+	RunnerRegion   string
+	GoArch         string
+	GoOS           string
+}

--- a/vpcs/upsert_vpcs_types.go
+++ b/vpcs/upsert_vpcs_types.go
@@ -54,6 +54,11 @@ type UpsertVpcsReplyV1 struct {
 	Done bool
 }
 
+type UpsertVpcsArgsV2 struct {
+	types.AuthArgsV2
+	Vpcs []UpsertVpcDtoV1
+}
+
 func GetSubnetsMapFromDto(subnetsFromDto []SubnetDtoV1) map[string]string {
 	subnetsMap := make(map[string]string)
 	for _, subnet := range subnetsFromDto {


### PR DESCRIPTION
…fferent AWS accounts

This commit introduces improvements to handle deployments on AWS with multiple VPCs and Clusters. It also extends support for specific Runner assignments and different AWS accounts based on environment. This makes the system more flexible when dealing with multiple AWS accounts or environments, better fitting diverse user needs. The update includes changes in multiple files related to deployment, job, and runner models, among others. Examples of changes include the addition of the `RunnerID` attribute in the environment and job models, the `CloudAccountID` in VPC and cluster models, and the check for the existence of a Runner ID when creating jobs.