### PR TITLE
feat(assistant job output support): Add support for CloudWatch monitoring and job output updates

### DIFF
--- a/cloud_api_clients/aws.go
+++ b/cloud_api_clients/aws.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -197,4 +198,22 @@ func GetAsgClient(region string) (*autoscaling.Client, error) {
 	})
 
 	return asgClient, nil
+}
+
+func GetCloudwatchClient(parameters map[string]interface{}) (*cloudwatch.Client, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	region, err := jobs.GetParameterValue[int64](parameters, parameters_enums.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	cloudwatchClient := cloudwatch.NewFromConfig(cfg, func(options *cloudwatch.Options) {
+		options.Region = region_enums.Type(region).String()
+	})
+
+	return cloudwatchClient, nil
 }

--- a/enums/commands_enums/types.go
+++ b/enums/commands_enums/types.go
@@ -23,6 +23,7 @@ const (
 	VerifyAcmCertificate                     Type = 14
 	DeleteAwsStaticSite                      Type = 15
 	DeleteAwsWebService                      Type = 16
+	ListCloudWatchMetricsAwsEcsWebService    Type = 17
 )
 
 var typeToString = map[Type]string{
@@ -42,6 +43,7 @@ var typeToString = map[Type]string{
 	VerifyAcmCertificate:                     "Verify ACM certificate",
 	DeleteAwsStaticSite:                      "Delete AWS Static Site",
 	DeleteAwsWebService:                      "Delete AWS Web Service",
+	ListCloudWatchMetricsAwsEcsWebService:    "List cloudwatch metrics for AWS ECS Web Service",
 }
 
 func (t Type) String() string {

--- a/enums/monitoring_enums/types.go
+++ b/enums/monitoring_enums/types.go
@@ -1,0 +1,15 @@
+package monitoring_enums
+
+type Type uint
+
+const (
+	Cloudwatch Type = iota + 1
+)
+
+var typeToString = map[Type]string{
+	Cloudwatch: "Cloudwatch",
+}
+
+func (t Type) String() string {
+	return typeToString[t]
+}

--- a/enums/parameters_enums/keys.go
+++ b/enums/parameters_enums/keys.go
@@ -57,18 +57,21 @@ const (
 	TaskDefinitionArn       Key = 45
 	InstallationId          Key = 46
 	//CpuArchitecture         Key = 47
-	ResponseHeaders    Key = 48
-	Domains            Key = 49
-	RedirectDomain     Key = 50
-	AcmCertificateArn  Key = 51
-	CertificateRegion  Key = 52
-	CertificateDomain  Key = 53
-	CertificateID      Key = 54
-	ParentDomain       Key = 55
-	CreateMultipleNats Key = 56
-	ErrorPages         Key = 57
-	PreviewID          Key = 58
-	IsPreview          Key = 59
+	ResponseHeaders      Key = 48
+	Domains              Key = 49
+	RedirectDomain       Key = 50
+	AcmCertificateArn    Key = 51
+	CertificateRegion    Key = 52
+	CertificateDomain    Key = 53
+	CertificateID        Key = 54
+	ParentDomain         Key = 55
+	CreateMultipleNats   Key = 56
+	ErrorPages           Key = 57
+	PreviewID            Key = 58
+	IsPreview            Key = 59
+	EcsClusterName       Key = 60
+	ShouldSendChatOutput Key = 61
+	JobID                Key = 62
 )
 
 var keyToString = map[Key]string{
@@ -119,18 +122,21 @@ var keyToString = map[Key]string{
 	TaskDefinitionArn:       "task definition arn",
 	InstallationId:          "installation id",
 	//CpuArchitecture:         "cpu architecture",
-	ResponseHeaders:    "response headers",
-	Domains:            "domains",
-	RedirectDomain:     "redirect domain",
-	AcmCertificateArn:  "ACM certificate Arn",
-	CertificateRegion:  "Certificate region",
-	CertificateDomain:  "Certificate domain",
-	CertificateID:      "Certificate ID",
-	ParentDomain:       "Parent domain",
-	CreateMultipleNats: "Create multiple nats",
-	ErrorPages:         "error pages",
-	PreviewID:          "Preview ID",
-	IsPreview:          "Is the job of type preview",
+	ResponseHeaders:      "response headers",
+	Domains:              "domains",
+	RedirectDomain:       "redirect domain",
+	AcmCertificateArn:    "ACM certificate Arn",
+	CertificateRegion:    "Certificate region",
+	CertificateDomain:    "Certificate domain",
+	CertificateID:        "Certificate ID",
+	ParentDomain:         "Parent domain",
+	CreateMultipleNats:   "Create multiple nats",
+	ErrorPages:           "error pages",
+	PreviewID:            "Preview ID",
+	IsPreview:            "Is the job of type preview",
+	EcsClusterName:       "ECS cluster name",
+	ShouldSendChatOutput: "Should output be sent back to the chat",
+	JobID:                "job Id",
 }
 
 func (k Key) String() string {
@@ -189,18 +195,21 @@ var keyMap = map[Key]string{
 	TaskDefinitionArn:       "45",
 	InstallationId:          "46",
 	//CpuArchitecture:         "47",
-	ResponseHeaders:    "48", //[][]string/primitive.A
-	Domains:            "49", //[]string/primitive.A
-	RedirectDomain:     "50", //[]string/primitive.A - 0th element is from and 1st element is to
-	AcmCertificateArn:  "51",
-	CertificateRegion:  "52",
-	CertificateDomain:  "53",
-	CertificateID:      "54",
-	ParentDomain:       "55",
-	CreateMultipleNats: "56",
-	ErrorPages:         "57", //[][]string/primitive.A
-	PreviewID:          "58",
-	IsPreview:          "59",
+	ResponseHeaders:      "48", //[][]string/primitive.A
+	Domains:              "49", //[]string/primitive.A
+	RedirectDomain:       "50", //[]string/primitive.A - 0th element is from and 1st element is to
+	AcmCertificateArn:    "51",
+	CertificateRegion:    "52",
+	CertificateDomain:    "53",
+	CertificateID:        "54",
+	ParentDomain:         "55",
+	CreateMultipleNats:   "56",
+	ErrorPages:           "57", //[][]string/primitive.A
+	PreviewID:            "58",
+	IsPreview:            "59",
+	EcsClusterName:       "60",
+	ShouldSendChatOutput: "61",
+	JobID:                "62",
 }
 
 func (k Key) Key() (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deployment-io/deployment-runner-kit
 go 1.20
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.26.1
+	github.com/aws/aws-sdk-go-v2 v1.27.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/acm v1.25.4
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5
@@ -22,10 +22,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.38.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=
 github.com/aws/aws-sdk-go-v2 v1.26.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
+github.com/aws/aws-sdk-go-v2 v1.27.2 h1:pLsTXqX93rimAOZG2FIYraDQstZaaGVVN4tNw65v0h8=
+github.com/aws/aws-sdk-go-v2 v1.27.2/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 h1:x6xsQXGSmW6frevwDA+vi/wqhp1ct18mVXYN08/93to=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2/go.mod h1:lPprDr1e6cJdyYeGXnRaJoP4Md+cDBvi2eOj00BlGmg=
 github.com/aws/aws-sdk-go-v2/config v1.27.11 h1:f47rANd2LQEYHda2ddSCKYId18/8BhSRM4BULGmfgNA=
@@ -10,8 +12,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 h1:FVJ0r5XTHSmIHJV6KuDmdYh
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1/go.mod h1:zusuAeqezXzAB24LGuzuekqMAEgWkVYukBec3kr3jUg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5 h1:aw39xVGeRWlWx9EzGVnhOR4yOjQDHPQ6o6NmBlscyQg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5/go.mod h1:FSaRudD0dXiMPK2UjknVwwTYyZMRsHv3TtkabsZih5I=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9 h1:cy8ahBJuhtM8GTTSyOkfy6WVPV1IE+SS5/wfXUYuulw=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9/go.mod h1:CZBXGLaJnEZI6EVNcPd7a6B5IC5cA/GkRWtu9fp3S6Y=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5 h1:PG1F3OD1szkuQPzDw3CIQsRIrtTlUC3lP84taWzHlq0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5/go.mod h1:jU1li6RFryMz+so64PpKtudI+QzbKoIEivqdf6LNpOc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 h1:A4SYk07ef04+vxZToz9LWvAXl9LW0NClpPpMsi31cz0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9/go.mod h1:5jJcHuwDagxN+ErjQ3PU3ocf6Ylc/p9x+BLO/+X4iXw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7jMrYJVDWI+f+VxU=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.5 h1:81KE7vaZzrl7yHBYHVEzYB8sypz11NMOZ40YlWvPxsU=
@@ -22,6 +28,8 @@ github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5 h1:vhdJymxlWS2qftzLiuCj
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.5/go.mod h1:ZErgk/bPaaZIpj+lUWGlwI1A0UFhSIscgnCPzTLnb2s=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0 h1:KbT1H0KXc26/M6km03gBWz5v1M5aOq4Cwo+aXJ2BpfM=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.36.0/go.mod h1:Pphkts8iBnexoEpcMti5fUvN3/yoGRLtl2heOeppF70=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.38.6 h1:UVjxYe8VGpwXYcmBcciBHlQrNssdEvntXCPWmnRR15U=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.38.6/go.mod h1:4V6VDA0kZavRn71+sLpVna75oobnlG+gwtnNcBwZhu4=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.156.0 h1:TFK9GeUINErClL2+A+GLYhjiChVdaXCgIUiCsS/UQrE=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.156.0/go.mod h1:xejKuuRDjz6z5OqyeLsz01MlOqqW7CqpAB4PabNvpu8=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.27.4 h1:Qr9W21mzWT3RhfYn9iAux7CeRIdbnTAqmiOlASqQgZI=

--- a/jobs/update_job_output_types.go
+++ b/jobs/update_job_output_types.go
@@ -1,0 +1,19 @@
+package jobs
+
+import (
+	"github.com/deployment-io/deployment-runner-kit/types"
+)
+
+type UpdateJobOutputDtoV1 struct {
+	ID     string
+	Output string
+}
+
+type UpdateJobOutputArgsV1 struct {
+	types.AuthArgsV1
+	Jobs []UpdateJobOutputDtoV1
+}
+
+type UpdateJobOutputReplyV1 struct {
+	Done bool
+}


### PR DESCRIPTION
This update adds CloudWatch support to the AWS client and refactors job-related files to include environment data decryption. It includes a functionality to relay job output back to the chat, new output messages and updates are handled as streams. It also involves modification in cluster extraction and job creation.