### PR TITLE
feature(nixpacks support): Remove Elixir support temporarily and upda…

### DIFF
--- a/enums/deployment_enums/runtime.go
+++ b/enums/deployment_enums/runtime.go
@@ -18,7 +18,7 @@ const (
 )
 
 func GetRuntimes() []Runtime {
-	return []Runtime{Docker, Elixir, Go, Node, Python3, Ruby, Rust}
+	return []Runtime{Docker, Go, Node, Python3, Rust}
 }
 
 var runtimeToString = map[Runtime]string{
@@ -26,7 +26,7 @@ var runtimeToString = map[Runtime]string{
 	Elixir:  "Elixir",
 	Go:      "Go",
 	Node:    "Node",
-	Python3: "Python3",
+	Python3: "Python",
 	Ruby:    "Ruby",
 	Rust:    "Rust",
 }


### PR DESCRIPTION
…te Python string in runtimes

Elixir runtime has been removed from the available runtimes in the GetRuntimes function. Additionally, the string representation of "Python3" has been updated to "Python" in the runtimeToString map.