### PR TITLE
feature(parameters): Add `IsSpa` key to parameters enums

### DIFF
--- a/enums/parameters_enums/keys.go
+++ b/enums/parameters_enums/keys.go
@@ -107,6 +107,7 @@ const (
 	AgentID                      Key = 93
 	DebugAgent                   Key = 94
 	DebugOpenAICallsInAgent      Key = 95
+	IsSpa                        Key = 96
 )
 
 var keyToString = map[Key]string{
@@ -205,6 +206,7 @@ var keyToString = map[Key]string{
 	AgentID:                      "agent id",
 	DebugAgent:                   "debug agent",
 	DebugOpenAICallsInAgent:      "debug open ai calls in agent",
+	IsSpa:                        "is spa",
 }
 
 func (k Key) String() string {
@@ -311,6 +313,7 @@ var keyMap = map[Key]string{
 	AgentID:                      "93",
 	DebugAgent:                   "94",
 	DebugOpenAICallsInAgent:      "95",
+	IsSpa:                        "96",
 }
 
 func (k Key) Key() (string, error) {


### PR DESCRIPTION
Introduced the `IsSpa` key to the parameters enums for enhanced mapping and string conversion capabilities.