### PR TITLE
Add ClaudeCodeVersion parameter key

### DIFF
--- a/enums/parameters_enums/keys.go
+++ b/enums/parameters_enums/keys.go
@@ -128,6 +128,7 @@ const (
 	AgentboxImage                Key = 114 //string - the agentbox Docker image reference (e.g., "deploymenthq/agentbox:1.0.0")
 	AgentType                    Key = 115 //string - agentbox AGENT_TYPE selector ("claude-code" in v1)
 	AdditionalAllowedHosts       Key = 116 //string - comma-separated extra hostnames the agentbox proxy will allow (org-level + future per-Task additions; runner unions sources before passing to container)
+	ClaudeCodeVersion            Key = 117 //string - pinned @anthropic-ai/claude-code version installed inside agentbox (e.g., "2.1.141"); empty = use the agentbox image's Dockerfile-baked default
 )
 
 var keyToString = map[Key]string{
@@ -247,6 +248,7 @@ var keyToString = map[Key]string{
 	AgentboxImage:                "agentbox image",
 	AgentType:                    "agent type",
 	AdditionalAllowedHosts:       "additional allowed hosts",
+	ClaudeCodeVersion:            "claude code version",
 }
 
 func (k Key) String() string {
@@ -374,6 +376,7 @@ var keyMap = map[Key]string{
 	AgentboxImage:                "114",
 	AgentType:                    "115",
 	AdditionalAllowedHosts:       "116",
+	ClaudeCodeVersion:            "117",
 }
 
 func (k Key) Key() (string, error) {


### PR DESCRIPTION
New Job param Key=117 that pins the @anthropic-ai/claude-code npm version installed inside the agentbox container at startup. Empty value means "use the agentbox image's Dockerfile-baked default"; the runner uses the empty-skip pattern when injecting it as the CLAUDE_CODE_VERSION env on the container.

Source-of-truth is a server-side env var on app-server (no per-Task override, no chained-Step inheritance) — see the kit side for the env-var resolution.