### PR TITLE
oauth: add GetOpenPullRequestForBranchV1 RPC args + dto

### DIFF
--- a/oauth/get_open_pull_request_for_branch.go
+++ b/oauth/get_open_pull_request_for_branch.go
@@ -1,0 +1,42 @@
+package oauth
+
+import "github.com/deployment-io/deployment-runner-kit/types"
+
+// GetOpenPullRequestForBranchArgsV1 is the runner→deployment-server RPC
+// payload for the read-only counterpart of OpenPullRequestV1. The server
+// looks up the installation, dispatches on provider, and returns the
+// most recent PR matching {RepoName, HeadBranch} or absence. Used by
+// the runner's re-run flow (see Q15 in PLAN_tasks_verification.md) to
+// decide whether to branch from base (no PR / closed-unmerged) or from
+// the existing PR head (open), and to fail loudly when re-running
+// against a merged PR.
+//
+// Same identifier conventions as OpenPullRequestArgsV1 — RepoName is
+// "owner/repo" on GitHub / BitBucket, numeric ID or "namespace/path"
+// on GitLab. Server interprets via installation.OauthProvider.
+type GetOpenPullRequestForBranchArgsV1 struct {
+	types.AuthArgsV1
+	InstallationID string
+	RepoName       string
+	HeadBranch     string
+}
+
+// GetOpenPullRequestForBranchDtoV1 is the normalized response. Found
+// discriminates "no PR has ever existed for this head" from "PR exists,
+// here's its state." When Found is true, State and Merged together let
+// the caller decide: open → iterate on this branch; closed+merged →
+// the work is already in base, fail the re-run loudly; closed+!merged →
+// treat as clean slate and re-attempt from base.
+//
+// HeadBranch / BaseBranch / HeadSHA are surfaced so the caller can
+// fetch + checkout precisely without a second round-trip.
+type GetOpenPullRequestForBranchDtoV1 struct {
+	Found      bool
+	PRNumber   int
+	URL        string
+	State      string // "open" or "closed" — provider-normalized.
+	Merged     bool   // True only when State == "closed" AND the PR was merged.
+	HeadBranch string
+	BaseBranch string
+	HeadSHA    string
+}


### PR DESCRIPTION
## Summary

Adds the RPC args + dto types for a new \`Oauth.GetOpenPullRequestForBranchV1\` method on deployment-server. Mirrors \`OpenPullRequestArgsV1\` / \`OpenPullRequestDtoV1\`'s shape; minus the create-time fields.

## Context

This is **step 2 of a four-repo dependency chain** for Q15 in \`PLAN_tasks_verification.md\` — the runner's re-run flow currently fails with \`non-fast-forward update\` because it can't ask deployment-server "is there an open PR for this branch?" before deciding the checkout base.

| # | Repo | Status |
|---|---|---|
| 1 | kit (provider impl + interface) | ✅ [#164](https://github.com/deployment-io/kit/pull/164) merged |
| 2 | **deployment-runner-kit (this PR)** | ⏳ in review |
| 3 | deployment-server (RPC method) | Waiting on this + a kit tag |
| 4 | deployment-runner (client + checkout logic) | Waiting on (3) deploy |

## What's in this PR

A single new file \`oauth/get_open_pull_request_for_branch.go\` with two type definitions:

\`\`\`go
type GetOpenPullRequestForBranchArgsV1 struct {
    types.AuthArgsV1
    InstallationID string
    RepoName       string
    HeadBranch     string
}

type GetOpenPullRequestForBranchDtoV1 struct {
    Found      bool
    PRNumber   int
    URL        string
    State      string // "open" or "closed" — provider-normalized.
    Merged     bool   // True only when State == "closed" AND the PR was merged.
    HeadBranch string
    BaseBranch string
    HeadSHA    string
}
\`\`\`

## Why the response shape distinguishes Found / State / Merged

The runner's re-run state machine needs to distinguish four cases:

| Case | Found | State | Merged | Runner action |
|---|---|---|---|---|
| First run / no PR ever | \`false\` | — | — | branch from base |
| Open PR exists | \`true\` | \`"open"\` | \`false\` | branch from PR head (Q15 happy path) |
| PR was merged | \`true\` | \`"closed"\` | \`true\` | fail loudly — work already in base |
| PR closed without merge | \`true\` | \`"closed"\` | \`false\` | branch from base (clean slate) |

## Test plan

- [x] \`go build ./...\` — green
- [x] \`go vet ./oauth/...\` — clean
- [x] \`go test ./oauth/...\` — no test files (consistent with the existing \`oauth/\` package pattern)
- [ ] After merge + tag: consume from deployment-server PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)