### PR TITLE
Add UpdateTaskStepRunning RPC types (runner-reported Task start)

### DIFF
--- a/tasks/update_tasks_types.go
+++ b/tasks/update_tasks_types.go
@@ -1,0 +1,30 @@
+package tasks
+
+import "github.com/deployment-io/deployment-runner-kit/types"
+
+// UpdateTaskStepRunningDtoV1 reports that the runner has begun executing a
+// Task Step — sent from CheckoutRepository.runForTask at checkout, the moment
+// real work starts. On receipt deployment-server flips, idempotently from
+// Pending: the Task -> Running, the Step -> StepRunning, and the agent-run Job
+// -> Running. Mirrors how builds.UpdateBuildDtoV1 carries the runner-reported
+// build Running status at checkout.
+//
+// Carries only identifiers — no state enum. Task/Step states live in kit's
+// task_enums, which this lower-layer package can't import; the server-side
+// handler owns the enum mapping.
+type UpdateTaskStepRunningDtoV1 struct {
+	TaskID    string
+	StepIndex int
+	JobID     string
+}
+
+// UpdateTaskStepRunningArgsV1 is the RPC envelope — a batch of step-started
+// reports, mirroring builds.UpdateBuildsArgsV1.
+type UpdateTaskStepRunningArgsV1 struct {
+	types.AuthArgsV1
+	Updates []UpdateTaskStepRunningDtoV1
+}
+
+type UpdateTaskStepRunningReplyV1 struct {
+	Done bool
+}


### PR DESCRIPTION
Phase 1 foundation for the Task lifecycle state-machine fix (`plans/PLAN_tasks_lifecycle_state.md`).

Tasks flip to `Running` at **job creation** today — before the runner picks the job up — so the card shows `Running` while the Step job is still `Pending`. The fix mirrors **builds**: the runner reports "started" at checkout (`checkout_repository.go` → `build_enums.Running`) and the control plane flips state then.

This PR is just the **wire types** for that report — a batch of `{TaskID, StepIndex, JobID}`, mirroring `builds.UpdateBuildDtoV1`/`UpdateBuildsArgsV1`. Identifiers only: `task_enums` live in kit (which this lower layer can't import), so the deployment-server handler owns the `Task→Running` / `Step→StepRunning` / `Job→Running` mapping.

Consumed next by deployment-server (the RPC handler) and deployment-runner (the pipeline + checkout call). Verified: `GOWORK=off go build ./... / vet` green.