### PR TITLE
Assistant session bridge: contract (enum, DTOs, param)

### DIFF
--- a/enums/commands_enums/types.go
+++ b/enums/commands_enums/types.go
@@ -32,6 +32,7 @@ const (
 	RunAgentStep                             Type = 27
 	CommitAndPush                            Type = 28
 	OpenPullRequest                          Type = 29
+	RunAssistantSession                      Type = 30
 )
 
 var typeToString = map[Type]string{
@@ -64,6 +65,7 @@ var typeToString = map[Type]string{
 	RunAgentStep:                             "Run Agent Step",
 	CommitAndPush:                            "Commit and Push",
 	OpenPullRequest:                          "Open Pull Request",
+	RunAssistantSession:                      "Run Assistant Session",
 }
 
 func (t Type) String() string {

--- a/enums/parameters_enums/keys.go
+++ b/enums/parameters_enums/keys.go
@@ -130,6 +130,7 @@ const (
 	AdditionalAllowedHosts       Key = 116 //string - comma-separated extra hostnames the agentbox proxy will allow (org-level + future per-Task additions; runner unions sources before passing to container)
 	ClaudeCodeVersion            Key = 117 //string - pinned @anthropic-ai/claude-code version installed inside agentbox (e.g., "2.1.141"); empty = use the agentbox image's Dockerfile-baked default
 	CodexVersion                 Key = 118 //string - pinned @openai/codex version installed inside agentbox (e.g., "0.136.0"); empty = use the agentbox image's Dockerfile-baked default
+	SessionUUID                  Key = 119 //string - stable Assistant-session UUID forwarded to agentbox as SESSION_ID (the agent's --session-id) for conversation continuity / crash recovery across re-runs
 )
 
 var keyToString = map[Key]string{
@@ -251,6 +252,7 @@ var keyToString = map[Key]string{
 	AdditionalAllowedHosts:       "additional allowed hosts",
 	ClaudeCodeVersion:            "claude code version",
 	CodexVersion:                 "codex version",
+	SessionUUID:                  "session uuid",
 }
 
 func (k Key) String() string {
@@ -380,6 +382,7 @@ var keyMap = map[Key]string{
 	AdditionalAllowedHosts:       "116",
 	ClaudeCodeVersion:            "117",
 	CodexVersion:                 "118",
+	SessionUUID:                  "119",
 }
 
 func (k Key) Key() (string, error) {

--- a/sessions/append_message_types.go
+++ b/sessions/append_message_types.go
@@ -1,0 +1,28 @@
+package sessions
+
+import "github.com/deployment-io/deployment-runner-kit/types"
+
+// AppendMessageDtoV1 is one incremental assistant-message update streamed from
+// the runner to deployment-server during an interactive Assistant session.
+//
+// A session Job produces many of these (unlike the one-shot devops agent).
+// Deltas of a single assistant message share MessageID and arrive with
+// IsDone=false (Content is the new text fragment emitted by agentbox); the
+// terminating update sets IsDone=true. deployment-server maps JobID→Thread and
+// appends a message_stream record per update (persisting the Message when
+// IsDone), reusing the same SSE path the devops agent already uses.
+type AppendMessageDtoV1 struct {
+	JobID     string
+	MessageID string // stable per assistant message; the UI coalesces deltas by it
+	Content   string // text fragment (delta) for this update
+	IsDone    bool   // marks the assistant message complete
+}
+
+type AppendMessageArgsV1 struct {
+	types.AuthArgsV1
+	Messages []AppendMessageDtoV1
+}
+
+type AppendMessageReplyV1 struct {
+	Done bool
+}

--- a/sessions/get_input_types.go
+++ b/sessions/get_input_types.go
@@ -1,0 +1,27 @@
+package sessions
+
+import "github.com/deployment-io/deployment-runner-kit/types"
+
+// UserMessageDtoV1 is one user turn the runner pulls from deployment-server to
+// feed the live agent (written into agentbox's .agentbox-input/messages/). The
+// user types in the browser, app-server persists the message, and the runner
+// polls for undelivered turns and forwards them to the running session.
+type UserMessageDtoV1 struct {
+	ID      string
+	Content string
+	Ts      int64
+}
+
+// GetInputArgsV1 asks for user turns newer than AfterTs for the session Job's
+// thread. The runner keeps AfterTs as an in-memory high-water mark for the
+// session's lifetime (the command runs for the whole session), so the server
+// stays stateless — it returns User messages with Ts > AfterTs, ordered.
+type GetInputArgsV1 struct {
+	types.AuthArgsV1
+	JobID   string
+	AfterTs int64
+}
+
+type GetInputReplyV1 struct {
+	Messages []UserMessageDtoV1
+}

--- a/sessions/update_spec_types.go
+++ b/sessions/update_spec_types.go
@@ -1,0 +1,29 @@
+package sessions
+
+import "github.com/deployment-io/deployment-runner-kit/types"
+
+// UpdateSpecDtoV1 is the latest structured task-spec the planning agent emitted
+// during a session (agentbox's task-spec.json), forwarded by the runner to
+// deployment-server, which persists it to Session.StructuredSpec. Sent whenever
+// the spec file changes (the agent refines it across turns).
+type UpdateSpecDtoV1 struct {
+	JobID       string
+	Title       string
+	Goal        string
+	Context     string
+	Acceptance  []string
+	Assumptions []string
+	OutOfScope  []string
+	Complexity  string
+	Readiness   string
+	Notes       string
+}
+
+type UpdateSpecArgsV1 struct {
+	types.AuthArgsV1
+	Spec UpdateSpecDtoV1
+}
+
+type UpdateSpecReplyV1 struct {
+	Done bool
+}


### PR DESCRIPTION
## Summary
Foundation/contract for the interactive **Assistant session** runner bridge (part of the Assistant feature — repo-aware sessions → Task specs). Consumed by deployment-server and deployment-runner.

- `commands_enums.RunAssistantSession` (30) — the runner command that runs a long-lived interactive session Job.
- `sessions` package — `AppendMessageV1` (runner streams agent output deltas: JobID, minted MessageID, Content, IsDone) and `GetInputV1` (runner pulls thread user turns newer than a high-water Ts).
- `parameters_enums.SessionUUID` (119) → forwarded to agentbox as `SESSION_ID`.

**Merge first** — the deployment-server and deployment-runner PRs depend on these types.

## Test plan
Builds green standalone (`GOWORK=off go build ./...`) and through the Assistant workspace overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)