### PR TITLE
Add TurnEnd message type and AppendMessageDtoV1.TurnEnd

### DIFF
--- a/enums/message_enums/message_types.go
+++ b/enums/message_enums/message_types.go
@@ -8,6 +8,11 @@ const (
 	User Type = iota + 1
 	Assistant
 	Output
+	// TurnEnd is a control record, not chat content: the session agent
+	// finished its turn and is waiting for the next user message. Carries no
+	// content; the UI uses it to gate the composer and group a turn's
+	// messages.
+	TurnEnd
 	MaxType //always add new types before MaxType
 )
 
@@ -15,6 +20,7 @@ var typeToString = map[Type]string{
 	User:      "user",
 	Assistant: "assistant",
 	Output:    "output",
+	TurnEnd:   "turnEnd",
 }
 
 func (t Type) String() string {
@@ -29,6 +35,8 @@ func StringToType(typeStr string) (Type, error) {
 		return Assistant, nil
 	case "output":
 		return Output, nil
+	case "turnEnd":
+		return TurnEnd, nil
 	default:
 		return 0, fmt.Errorf("invalid message type")
 	}

--- a/sessions/append_message_types.go
+++ b/sessions/append_message_types.go
@@ -16,6 +16,12 @@ type AppendMessageDtoV1 struct {
 	MessageID string // stable per assistant message; the UI coalesces deltas by it
 	Content   string // text fragment (delta) for this update
 	IsDone    bool   // marks the assistant message complete
+	// TurnEnd marks the agent's turn boundary: it finished its reply and is
+	// waiting for the next user message. Sent as its own update (no Content,
+	// IsDone=true, fresh MessageID); deployment-server records it as a
+	// message_enums.TurnEnd message so the UI can gate its composer on the
+	// boundary (ping-pong) and group a turn's messages.
+	TurnEnd bool
 }
 
 type AppendMessageArgsV1 struct {


### PR DESCRIPTION
## Summary
Carries the Assistant-session agent's turn boundary (finished replying, waiting for the next user message) from the runner to deployment-server. `TurnEnd` is a control record, not chat content: the update has no `Content`, ships with `IsDone` + a fresh `MessageID`, and persists as `message_enums.TurnEnd` (string `"turnEnd"`, added before `MaxType`). The dashboard gates its composer on it (ping-pong) and can group a turn's messages.

## Merge order
**Merge this first** — the deployment-runner and deployment-server PRs reference the new enum/DTO field, and app-server needs a go.mod bump to this version so `Type.String()` knows "turnEnd" (no app-server code changes).

## Verification
- `GOWORK=off go build ./...`
- deployment-runner, deployment-server, and app-server all build/vet/test green against this via a workspace overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)