### PR TITLE
Explore P0: BuildInfraContext command + context_pack DTO types

### DIFF
--- a/context_pack/get_context.go
+++ b/context_pack/get_context.go
@@ -1,0 +1,23 @@
+package context_pack
+
+import "github.com/deployment-io/deployment-runner-kit/types"
+
+// MaterializeContextArgsV1 asks deployment-server for the context to drop into an agent run's
+// /work/context, for the given scopes (Org always; environment/cluster added later).
+type MaterializeContextArgsV1 struct {
+	types.AuthArgsV1
+	Scopes []Scope
+}
+
+// ContextFileV1 is one file to write under /work/context (Path is relative, e.g. "repos.json").
+// The server renders packs to files so the runner only writes bytes — and so the RPC payload
+// stays gob-simple: no Artifact.Data interface{} crosses the wire.
+type ContextFileV1 struct {
+	Path    string
+	Content string
+}
+
+// MaterializeContextReplyV1 is the rendered context for the requested scopes.
+type MaterializeContextReplyV1 struct {
+	Files []ContextFileV1
+}

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -49,10 +49,29 @@ type MarkdownFile struct {
 	Content string `json:"content" bson:"content"`
 }
 
-// Pack is the full output of a BuildInfraContext run: structured-canonical Artifacts indexed
-// by a Manifest, plus the derived Markdown projection.
+// Pack is one scope's slice of context: structured-canonical Artifacts indexed by a Manifest,
+// plus the derived Markdown projection. A BuildInfraContext run emits one Pack per scope (see
+// ScopedPack); the agent's /work/context/ is composed from the packs whose scope covers its
+// target.
 type Pack struct {
 	Manifest  Manifest       `json:"manifest" bson:"manifest"`
 	Artifacts []Artifact     `json:"artifacts" bson:"artifacts"`
 	Markdown  []MarkdownFile `json:"markdown" bson:"markdown"`
+}
+
+// Scope is the breadth a stored context record applies to: a level plus the id of the entity
+// at that level (an environment/cluster id; empty for Org). Records are keyed by Scope so
+// org-wide content is stored once and per-cluster content once — never duplicated per
+// environment.
+type Scope struct {
+	Level context_pack_enums.ScopeLevel `json:"level" bson:"level"`
+	ID    string                        `json:"id,omitempty" bson:"id,omitempty"`
+}
+
+// ScopedPack is the unit a BuildInfraContext run emits and deployment-server persists: one
+// scope's content, stored as a single context_packs record per (org, scope). A run produces a
+// []ScopedPack — the sources' outputs grouped by their scope.
+type ScopedPack struct {
+	Scope Scope `json:"scope" bson:"scope"`
+	Pack  Pack  `json:"pack" bson:"pack"`
 }

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -42,21 +42,18 @@ type Artifact struct {
 	Data interface{} `json:"data" bson:"data"`
 }
 
-// MarkdownFile is a derived markdown projection of the structured data — the view the agent
-// reads. Regenerable from the Artifacts; gzipped at the storage layer.
-type MarkdownFile struct {
-	Path    string `json:"path" bson:"path"`
-	Content string `json:"content" bson:"content"`
-}
-
-// Pack is one scope's slice of context: structured-canonical Artifacts indexed by a Manifest,
-// plus the derived Markdown projection. A BuildInfraContext run emits one Pack per scope (see
+// Pack is one scope's slice of context — the canonical, queryable data we persist: structured
+// Artifacts indexed by a Manifest. A BuildInfraContext run emits one Pack per scope (see
 // ScopedPack); the agent's /work/context/ is composed from the packs whose scope covers its
 // target.
+//
+// The agent-facing markdown is deliberately NOT stored here. It's a deterministic projection
+// of the Artifacts, regenerated cheaply at materialization by the renderer — so derived data
+// isn't stored twice, and renderer improvements apply to old packs automatically. LLM-derived
+// narrative prose, which can't be cheaply regenerated, is stored as an Artifact instead.
 type Pack struct {
-	Manifest  Manifest       `json:"manifest" bson:"manifest"`
-	Artifacts []Artifact     `json:"artifacts" bson:"artifacts"`
-	Markdown  []MarkdownFile `json:"markdown" bson:"markdown"`
+	Manifest  Manifest   `json:"manifest" bson:"manifest"`
+	Artifacts []Artifact `json:"artifacts" bson:"artifacts"`
 }
 
 // Scope is the breadth a stored context record applies to: a level plus the id of the entity

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -3,9 +3,9 @@
 // persists into the per-org context_packs collection.
 //
 // The pack is structured-canonical: typed Artifacts (the source of truth, queryable once in
-// BSON) indexed by a Manifest, plus a derived Markdown projection (the view the agent reads,
-// gzipped at the storage layer). The runner marshals a Pack to JSON into JobOutput; the
-// server unmarshals it and stores it.
+// BSON) indexed by a Manifest. The agent-facing markdown is not stored — it's regenerated from
+// the Artifacts at materialization. The runner marshals the per-scope packs to JSON into
+// JobOutput; the server unmarshals them and stores one record per (org, scope).
 package context_pack
 
 import "github.com/deployment-io/deployment-runner-kit/enums/context_pack_enums"
@@ -13,22 +13,22 @@ import "github.com/deployment-io/deployment-runner-kit/enums/context_pack_enums"
 // ManifestEntry indexes one file in the pack. It does quadruple duty: routing (Summary),
 // freshness (SyncedTs + TtlS), correctness honesty (Confidence), and drift (Hash).
 type ManifestEntry struct {
-	Path       string                        `json:"path" bson:"path"`
-	Source     string                        `json:"source" bson:"source"` // connector that produced it
-	SourceKind context_pack_enums.SourceKind `json:"sourceKind" bson:"sourceKind"`
-	Hash       string                        `json:"hash" bson:"hash"` // content hash, for drift detection
-	SyncedTs   int64                         `json:"syncedTs" bson:"syncedTs"`
-	TtlS       int64                         `json:"ttlS" bson:"ttlS"` // per-connector TTL, seconds
-	Confidence context_pack_enums.Confidence `json:"confidence" bson:"confidence"`
-	Summary    string                        `json:"summary" bson:"summary"` // one-line, redaction-clean
+	Path       string                        `json:"path,omitempty" bson:"path,omitempty"`
+	Source     string                        `json:"source,omitempty" bson:"source,omitempty"` // connector that produced it
+	SourceKind context_pack_enums.SourceKind `json:"sourceKind,omitempty" bson:"sourceKind,omitempty"`
+	Hash       string                        `json:"hash,omitempty" bson:"hash,omitempty"` // content hash, for drift detection
+	SyncedTs   int64                         `json:"syncedTs,omitempty" bson:"syncedTs,omitempty"`
+	TtlS       int64                         `json:"ttlS,omitempty" bson:"ttlS,omitempty"` // per-connector TTL, seconds
+	Confidence context_pack_enums.Confidence `json:"confidence,omitempty" bson:"confidence,omitempty"`
+	Summary    string                        `json:"summary,omitempty" bson:"summary,omitempty"` // one-line, redaction-clean
 }
 
 // Manifest is the pack index — the linchpin the agent reads first to route, and that the
 // dashboard and drift-diffing read for freshness and coverage.
 type Manifest struct {
-	PackVersion int             `json:"packVersion" bson:"packVersion"`
-	BuiltTs     int64           `json:"builtTs" bson:"builtTs"`
-	Files       []ManifestEntry `json:"files" bson:"files"`
+	PackVersion int             `json:"packVersion,omitempty" bson:"packVersion,omitempty"`
+	BuiltTs     int64           `json:"builtTs,omitempty" bson:"builtTs,omitempty"`
+	Files       []ManifestEntry `json:"files,omitempty" bson:"files,omitempty"`
 	// Gaps records what we could not see (auth can-i honesty) rather than implying
 	// completeness — e.g. "RBAC in ns 'payments': forbidden".
 	Gaps []string `json:"gaps,omitempty" bson:"gaps,omitempty"`
@@ -38,8 +38,8 @@ type Manifest struct {
 // canonical, queryable form. Data is left open (object or array) so each source owns its own
 // schema; it round-trips JSON -> server -> queryable BSON.
 type Artifact struct {
-	Name string      `json:"name" bson:"name"`
-	Data interface{} `json:"data" bson:"data"`
+	Name string      `json:"name,omitempty" bson:"name,omitempty"`
+	Data interface{} `json:"data,omitempty" bson:"data,omitempty"`
 }
 
 // Pack is one scope's slice of context — the canonical, queryable data we persist: structured
@@ -53,16 +53,21 @@ type Artifact struct {
 // narrative prose, which can't be cheaply regenerated, is stored as an Artifact instead.
 type Pack struct {
 	Manifest  Manifest   `json:"manifest" bson:"manifest"`
-	Artifacts []Artifact `json:"artifacts" bson:"artifacts"`
+	Artifacts []Artifact `json:"artifacts,omitempty" bson:"artifacts,omitempty"`
 }
 
 // Scope is the breadth a stored context record applies to: a level plus the id of the entity
 // at that level (an environment/cluster id; empty for Org). Records are keyed by Scope so
 // org-wide content is stored once and per-cluster content once — never duplicated per
 // environment.
+//
+// Level and ID are the upsert key, so they intentionally have NO omitempty: the Org scope's ID
+// is "", and omitempty would drop it from the stored doc — then the upsert filter {scope.id: ""}
+// would not match (Mongo treats an absent field as different from "") and every refresh would
+// insert a duplicate Org record.
 type Scope struct {
 	Level context_pack_enums.ScopeLevel `json:"level" bson:"level"`
-	ID    string                        `json:"id,omitempty" bson:"id,omitempty"`
+	ID    string                        `json:"id" bson:"id"`
 }
 
 // ScopedPack is the unit a BuildInfraContext run emits and deployment-server persists: one

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -1,0 +1,79 @@
+// Package context_pack defines the shared, serializable shape of an infra/repo "context
+// pack" — the artifact a BuildInfraContext runner command produces and deployment-server
+// persists into the per-org context_packs collection.
+//
+// The pack is structured-canonical: typed Artifacts (the source of truth, queryable once in
+// BSON) indexed by a Manifest, plus a derived Markdown projection (the view the agent reads,
+// gzipped at the storage layer). The runner marshals a Pack to JSON into JobOutput; the
+// server unmarshals it and stores it.
+package context_pack
+
+// SourceKind is the provenance of a context item. This single field lets the system absorb
+// new context types and acquisition modes as cases rather than bolt-ons.
+type SourceKind string
+
+const (
+	Discovered SourceKind = "discovered" // runner scan, deterministic
+	Fetched    SourceKind = "fetched"    // live API snapshot (short TTL)
+	Answered   SourceKind = "answered"   // human-confirmed (durable)
+	Derived    SourceKind = "derived"    // structural extract / LLM
+)
+
+// Confidence is the per-item correctness signal. Detection heuristics can be wrong, so
+// consumers treat low-confidence facts as "confirm live" before acting on them.
+type Confidence string
+
+const (
+	ConfidenceHigh   Confidence = "high"
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceLow    Confidence = "low"
+	ConfidenceNone   Confidence = "none"
+)
+
+// ManifestEntry indexes one file in the pack. It does quadruple duty: routing (Summary),
+// freshness (SyncedTs + TtlS), correctness honesty (Confidence), and drift (Hash).
+type ManifestEntry struct {
+	Path       string     `json:"path" bson:"path"`
+	Source     string     `json:"source" bson:"source"` // connector that produced it
+	SourceKind SourceKind `json:"sourceKind" bson:"sourceKind"`
+	Hash       string     `json:"hash" bson:"hash"` // content hash, for drift detection
+	SyncedTs   int64      `json:"syncedTs" bson:"syncedTs"`
+	TtlS       int64      `json:"ttlS" bson:"ttlS"` // per-connector TTL, seconds
+	Confidence Confidence `json:"confidence" bson:"confidence"`
+	Summary    string     `json:"summary" bson:"summary"` // one-line, redaction-clean
+}
+
+// Manifest is the pack index — the linchpin the agent reads first to route, and that the
+// dashboard and drift-diffing read for freshness and coverage.
+type Manifest struct {
+	PackVersion int             `json:"packVersion" bson:"packVersion"`
+	Environment string          `json:"environment" bson:"environment"`
+	BuiltTs     int64           `json:"builtTs" bson:"builtTs"`
+	Files       []ManifestEntry `json:"files" bson:"files"`
+	// Gaps records what we could not see (auth can-i honesty) rather than implying
+	// completeness — e.g. "RBAC in ns 'payments': forbidden".
+	Gaps []string `json:"gaps,omitempty" bson:"gaps,omitempty"`
+}
+
+// Artifact is one typed structured artifact (e.g. repos.json, infra-fingerprint.json) — the
+// canonical, queryable form. Data is left open (object or array) so each source owns its own
+// schema; it round-trips JSON -> server -> queryable BSON.
+type Artifact struct {
+	Name string      `json:"name" bson:"name"`
+	Data interface{} `json:"data" bson:"data"`
+}
+
+// MarkdownFile is a derived markdown projection of the structured data — the view the agent
+// reads. Regenerable from the Artifacts; gzipped at the storage layer.
+type MarkdownFile struct {
+	Path    string `json:"path" bson:"path"`
+	Content string `json:"content" bson:"content"`
+}
+
+// Pack is the full output of a BuildInfraContext run: structured-canonical Artifacts indexed
+// by a Manifest, plus the derived Markdown projection.
+type Pack struct {
+	Manifest  Manifest       `json:"manifest" bson:"manifest"`
+	Artifacts []Artifact     `json:"artifacts" bson:"artifacts"`
+	Markdown  []MarkdownFile `json:"markdown" bson:"markdown"`
+}

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -27,7 +27,6 @@ type ManifestEntry struct {
 // dashboard and drift-diffing read for freshness and coverage.
 type Manifest struct {
 	PackVersion int             `json:"packVersion" bson:"packVersion"`
-	Environment string          `json:"environment" bson:"environment"`
 	BuiltTs     int64           `json:"builtTs" bson:"builtTs"`
 	Files       []ManifestEntry `json:"files" bson:"files"`
 	// Gaps records what we could not see (auth can-i honesty) rather than implying

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -9,26 +9,53 @@
 package context_pack
 
 // SourceKind is the provenance of a context item. This single field lets the system absorb
-// new context types and acquisition modes as cases rather than bolt-ons.
-type SourceKind string
+// new context types and acquisition modes as cases rather than bolt-ons. Stored in the pack
+// (and thus in context_packs), so values are fixed and new kinds are appended before
+// MaxSourceKind — never renumbered.
+type SourceKind uint
 
 const (
-	Discovered SourceKind = "discovered" // runner scan, deterministic
-	Fetched    SourceKind = "fetched"    // live API snapshot (short TTL)
-	Answered   SourceKind = "answered"   // human-confirmed (durable)
-	Derived    SourceKind = "derived"    // structural extract / LLM
+	Discovered    SourceKind = iota + 1 // runner scan, deterministic
+	Fetched                             // live API snapshot (short TTL)
+	Answered                            // human-confirmed (durable)
+	Derived                             // structural extract / LLM
+	MaxSourceKind                       // always add new source kinds before MaxSourceKind
 )
+
+var sourceKindToString = map[SourceKind]string{
+	Discovered: "discovered",
+	Fetched:    "fetched",
+	Answered:   "answered",
+	Derived:    "derived",
+}
+
+func (s SourceKind) String() string {
+	return sourceKindToString[s]
+}
 
 // Confidence is the per-item correctness signal. Detection heuristics can be wrong, so
-// consumers treat low-confidence facts as "confirm live" before acting on them.
-type Confidence string
+// consumers treat low-confidence facts as "confirm live" before acting on them. Ordered
+// ascending (higher = more certain); appended before MaxConfidence, never renumbered.
+type Confidence uint
 
 const (
-	ConfidenceHigh   Confidence = "high"
-	ConfidenceMedium Confidence = "medium"
-	ConfidenceLow    Confidence = "low"
-	ConfidenceNone   Confidence = "none"
+	ConfidenceNone   Confidence = iota + 1 // could not determine
+	ConfidenceLow                          // weak heuristic
+	ConfidenceMedium                       // probable
+	ConfidenceHigh                         // human-confirmed or unambiguous
+	MaxConfidence                          // always add new levels before MaxConfidence
 )
+
+var confidenceToString = map[Confidence]string{
+	ConfidenceNone:   "none",
+	ConfidenceLow:    "low",
+	ConfidenceMedium: "medium",
+	ConfidenceHigh:   "high",
+}
+
+func (c Confidence) String() string {
+	return confidenceToString[c]
+}
 
 // ManifestEntry indexes one file in the pack. It does quadruple duty: routing (Summary),
 // freshness (SyncedTs + TtlS), correctness honesty (Confidence), and drift (Hash).

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -56,18 +56,18 @@ type Pack struct {
 	Artifacts []Artifact `json:"artifacts,omitempty" bson:"artifacts,omitempty"`
 }
 
-// Scope is the breadth a stored context record applies to: a level plus the id of the entity
-// at that level (an environment/cluster id; empty for Org). Records are keyed by Scope so
-// org-wide content is stored once and per-cluster content once — never duplicated per
+// Scope is the breadth a stored context record applies to: a level plus the id of the owning
+// entity — the org id for Org, an environment/cluster id otherwise. Records are keyed by Scope
+// so org-wide content is stored once and per-cluster content once — never duplicated per
 // environment.
 //
-// Level and ID are the upsert key, so they intentionally have NO omitempty: the Org scope's ID
-// is "", and omitempty would drop it from the stored doc — then the upsert filter {scope.id: ""}
-// would not match (Mongo treats an absent field as different from "") and every refresh would
-// insert a duplicate Org record.
+// The id is always a real, non-empty entity id (the Org scope's id is the org id, set on the
+// runner), so omitempty is safe and matches the codebase. And even when a key field is zero,
+// the upsert filter carries scope.level/id, so they're written into the doc on insert anyway —
+// the same reason _id can use omitempty (Mongo fills it in on insert).
 type Scope struct {
-	Level context_pack_enums.ScopeLevel `json:"level" bson:"level"`
-	ID    string                        `json:"id" bson:"id"`
+	Level context_pack_enums.ScopeLevel `json:"level,omitempty" bson:"level,omitempty"`
+	ID    string                        `json:"id,omitempty" bson:"id,omitempty"`
 }
 
 // ScopedPack is the unit a BuildInfraContext run emits and deployment-server persists: one

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -34,6 +34,13 @@ type Manifest struct {
 	Gaps []string `json:"gaps,omitempty" bson:"gaps,omitempty"`
 }
 
+// IsZero reports whether the manifest carries no content, so a Pack's Manifest field can be
+// elided under bson omitempty. The bson encoder calls IsZero for struct-typed fields — the
+// same mechanism that lets primitive.ObjectID use `_id,omitempty`.
+func (m Manifest) IsZero() bool {
+	return m.PackVersion == 0 && m.BuiltTs == 0 && len(m.Files) == 0 && len(m.Gaps) == 0
+}
+
 // Artifact is one typed structured artifact (e.g. repos.json, infra-fingerprint.json) — the
 // canonical, queryable form. Data is left open (object or array) so each source owns its own
 // schema; it round-trips JSON -> server -> queryable BSON.
@@ -52,7 +59,7 @@ type Artifact struct {
 // isn't stored twice, and renderer improvements apply to old packs automatically. LLM-derived
 // narrative prose, which can't be cheaply regenerated, is stored as an Artifact instead.
 type Pack struct {
-	Manifest  Manifest   `json:"manifest" bson:"manifest"`
+	Manifest  Manifest   `json:"manifest,omitempty" bson:"manifest,omitempty"`
 	Artifacts []Artifact `json:"artifacts,omitempty" bson:"artifacts,omitempty"`
 }
 

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -8,66 +8,19 @@
 // server unmarshals it and stores it.
 package context_pack
 
-// SourceKind is the provenance of a context item. This single field lets the system absorb
-// new context types and acquisition modes as cases rather than bolt-ons. Stored in the pack
-// (and thus in context_packs), so values are fixed and new kinds are appended before
-// MaxSourceKind — never renumbered.
-type SourceKind uint
-
-const (
-	Discovered    SourceKind = iota + 1 // runner scan, deterministic
-	Fetched                             // live API snapshot (short TTL)
-	Answered                            // human-confirmed (durable)
-	Derived                             // structural extract / LLM
-	MaxSourceKind                       // always add new source kinds before MaxSourceKind
-)
-
-var sourceKindToString = map[SourceKind]string{
-	Discovered: "discovered",
-	Fetched:    "fetched",
-	Answered:   "answered",
-	Derived:    "derived",
-}
-
-func (s SourceKind) String() string {
-	return sourceKindToString[s]
-}
-
-// Confidence is the per-item correctness signal. Detection heuristics can be wrong, so
-// consumers treat low-confidence facts as "confirm live" before acting on them. Ordered
-// ascending (higher = more certain); appended before MaxConfidence, never renumbered.
-type Confidence uint
-
-const (
-	ConfidenceNone   Confidence = iota + 1 // could not determine
-	ConfidenceLow                          // weak heuristic
-	ConfidenceMedium                       // probable
-	ConfidenceHigh                         // human-confirmed or unambiguous
-	MaxConfidence                          // always add new levels before MaxConfidence
-)
-
-var confidenceToString = map[Confidence]string{
-	ConfidenceNone:   "none",
-	ConfidenceLow:    "low",
-	ConfidenceMedium: "medium",
-	ConfidenceHigh:   "high",
-}
-
-func (c Confidence) String() string {
-	return confidenceToString[c]
-}
+import "github.com/deployment-io/deployment-runner-kit/enums/context_pack_enums"
 
 // ManifestEntry indexes one file in the pack. It does quadruple duty: routing (Summary),
 // freshness (SyncedTs + TtlS), correctness honesty (Confidence), and drift (Hash).
 type ManifestEntry struct {
-	Path       string     `json:"path" bson:"path"`
-	Source     string     `json:"source" bson:"source"` // connector that produced it
-	SourceKind SourceKind `json:"sourceKind" bson:"sourceKind"`
-	Hash       string     `json:"hash" bson:"hash"` // content hash, for drift detection
-	SyncedTs   int64      `json:"syncedTs" bson:"syncedTs"`
-	TtlS       int64      `json:"ttlS" bson:"ttlS"` // per-connector TTL, seconds
-	Confidence Confidence `json:"confidence" bson:"confidence"`
-	Summary    string     `json:"summary" bson:"summary"` // one-line, redaction-clean
+	Path       string                        `json:"path" bson:"path"`
+	Source     string                        `json:"source" bson:"source"` // connector that produced it
+	SourceKind context_pack_enums.SourceKind `json:"sourceKind" bson:"sourceKind"`
+	Hash       string                        `json:"hash" bson:"hash"` // content hash, for drift detection
+	SyncedTs   int64                         `json:"syncedTs" bson:"syncedTs"`
+	TtlS       int64                         `json:"ttlS" bson:"ttlS"` // per-connector TTL, seconds
+	Confidence context_pack_enums.Confidence `json:"confidence" bson:"confidence"`
+	Summary    string                        `json:"summary" bson:"summary"` // one-line, redaction-clean
 }
 
 // Manifest is the pack index — the linchpin the agent reads first to route, and that the

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -89,10 +89,12 @@ func (s Scope) IsZero() bool {
 	return s.Level == 0 && s.ID == ""
 }
 
-// ScopedPack is the unit a BuildInfraContext run emits and deployment-server persists: one
-// scope's content, stored as a single context_packs record per (org, scope). A run produces a
-// []ScopedPack — the sources' outputs grouped by their scope.
+// ScopedPack is the wire unit a BuildInfraContext run emits in JobOutput: one scope's content.
+// A run produces a []ScopedPack — the sources' outputs grouped by scope. It is JSON-only
+// (transport); deployment-server unpacks each into a per-(org, scope) context_packs record
+// (see the kit ContextPack model), so ScopedPack itself is never bson-marshaled — hence no
+// bson tags.
 type ScopedPack struct {
-	Scope Scope `json:"scope" bson:"scope"`
-	Pack  Pack  `json:"pack" bson:"pack"`
+	Scope Scope `json:"scope"`
+	Pack  Pack  `json:"pack"`
 }

--- a/context_pack/types.go
+++ b/context_pack/types.go
@@ -63,6 +63,12 @@ type Pack struct {
 	Artifacts []Artifact `json:"artifacts,omitempty" bson:"artifacts,omitempty"`
 }
 
+// IsZero reports whether the pack carries no content, so a Pack field can be elided under bson
+// omitempty (e.g. a partial ContextPack update that doesn't touch the pack).
+func (p Pack) IsZero() bool {
+	return p.Manifest.IsZero() && len(p.Artifacts) == 0
+}
+
 // Scope is the breadth a stored context record applies to: a level plus the id of the owning
 // entity — the org id for Org, an environment/cluster id otherwise. Records are keyed by Scope
 // so org-wide content is stored once and per-cluster content once — never duplicated per
@@ -75,6 +81,12 @@ type Pack struct {
 type Scope struct {
 	Level context_pack_enums.ScopeLevel `json:"level,omitempty" bson:"level,omitempty"`
 	ID    string                        `json:"id,omitempty" bson:"id,omitempty"`
+}
+
+// IsZero reports whether the scope is empty, so a Scope field can be elided under bson
+// omitempty (e.g. a partial ContextPack update that doesn't touch the scope).
+func (s Scope) IsZero() bool {
+	return s.Level == 0 && s.ID == ""
 }
 
 // ScopedPack is the unit a BuildInfraContext run emits and deployment-server persists: one

--- a/enums/commands_enums/types.go
+++ b/enums/commands_enums/types.go
@@ -33,6 +33,7 @@ const (
 	CommitAndPush                            Type = 28
 	OpenPullRequest                          Type = 29
 	RunAssistantSession                      Type = 30
+	BuildInfraContext                        Type = 31
 )
 
 var typeToString = map[Type]string{
@@ -66,6 +67,7 @@ var typeToString = map[Type]string{
 	CommitAndPush:                            "Commit and Push",
 	OpenPullRequest:                          "Open Pull Request",
 	RunAssistantSession:                      "Run Assistant Session",
+	BuildInfraContext:                        "Build Infra Context",
 }
 
 func (t Type) String() string {

--- a/enums/commands_enums/types.go
+++ b/enums/commands_enums/types.go
@@ -34,6 +34,7 @@ const (
 	OpenPullRequest                          Type = 29
 	RunAssistantSession                      Type = 30
 	BuildInfraContext                        Type = 31
+	MaterializeContext                       Type = 32
 )
 
 var typeToString = map[Type]string{
@@ -68,6 +69,7 @@ var typeToString = map[Type]string{
 	OpenPullRequest:                          "Open Pull Request",
 	RunAssistantSession:                      "Run Assistant Session",
 	BuildInfraContext:                        "Build Infra Context",
+	MaterializeContext:                       "Materialize Context",
 }
 
 func (t Type) String() string {

--- a/enums/context_pack_enums/confidence.go
+++ b/enums/context_pack_enums/confidence.go
@@ -1,0 +1,25 @@
+package context_pack_enums
+
+// Confidence is the per-item correctness signal. Detection heuristics can be wrong, so
+// consumers treat low-confidence facts as "confirm live" before acting on them. Ordered
+// ascending (higher = more certain); appended before MaxConfidence, never renumbered.
+type Confidence uint
+
+const (
+	ConfidenceNone   Confidence = iota + 1 // could not determine
+	ConfidenceLow                          // weak heuristic
+	ConfidenceMedium                       // probable
+	ConfidenceHigh                         // human-confirmed or unambiguous
+	MaxConfidence                          // always add new levels before MaxConfidence
+)
+
+var confidenceToString = map[Confidence]string{
+	ConfidenceNone:   "none",
+	ConfidenceLow:    "low",
+	ConfidenceMedium: "medium",
+	ConfidenceHigh:   "high",
+}
+
+func (c Confidence) String() string {
+	return confidenceToString[c]
+}

--- a/enums/context_pack_enums/scope_level.go
+++ b/enums/context_pack_enums/scope_level.go
@@ -1,0 +1,24 @@
+package context_pack_enums
+
+// ScopeLevel is the breadth a stored context record applies to. Records are keyed by scope so
+// org-wide data (e.g. the repo catalog) is stored once and per-cluster infra once, rather than
+// duplicated into every environment's pack. Stored, so values are fixed and new levels are
+// appended before MaxScopeLevel — never renumbered.
+type ScopeLevel uint
+
+const (
+	Org           ScopeLevel = iota + 1 // applies to the whole organization (e.g. repo catalog)
+	Environment                         // a specific deployment environment
+	Cluster                             // a specific K8s / compute cluster
+	MaxScopeLevel                       // always add new scope levels before MaxScopeLevel
+)
+
+var scopeLevelToString = map[ScopeLevel]string{
+	Org:         "org",
+	Environment: "environment",
+	Cluster:     "cluster",
+}
+
+func (s ScopeLevel) String() string {
+	return scopeLevelToString[s]
+}

--- a/enums/context_pack_enums/source_kind.go
+++ b/enums/context_pack_enums/source_kind.go
@@ -1,0 +1,26 @@
+package context_pack_enums
+
+// SourceKind is the provenance of a context item. This single field lets the system absorb
+// new context types and acquisition modes as cases rather than bolt-ons. Stored in the pack
+// (and thus in context_packs), so values are fixed and new kinds are appended before
+// MaxSourceKind — never renumbered.
+type SourceKind uint
+
+const (
+	Discovered    SourceKind = iota + 1 // runner scan, deterministic
+	Fetched                             // live API snapshot (short TTL)
+	Answered                            // human-confirmed (durable)
+	Derived                             // structural extract / LLM
+	MaxSourceKind                       // always add new source kinds before MaxSourceKind
+)
+
+var sourceKindToString = map[SourceKind]string{
+	Discovered: "discovered",
+	Fetched:    "fetched",
+	Answered:   "answered",
+	Derived:    "derived",
+}
+
+func (s SourceKind) String() string {
+	return sourceKindToString[s]
+}


### PR DESCRIPTION
**Review-only (draft) — root of the Explore/Context P0 foundation chain. Not for merge.**

Adds the `BuildInfraContext` command enum (`commands_enums` = 31, appended) and a new `context_pack` package: the serializable `Pack` shape a BuildInfraContext run produces and deployment-server persists — `SourceKind`/`Confidence`/`ManifestEntry`/`Manifest`/`Artifact`/`MarkdownFile`/`Pack`. json tags for JobOutput transport, bson tags for context_packs persistence.

Plan: `plans/PLAN_EXPLORE_CONTEXT.md` (P0).

**4-PR merge order:** this (root) → `kit` → `deployment-runner` / `deployment-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)