### PR TITLE
context_pack: SourceAnsweredServiceMap — the human-confirmed service↔repo source

### DIFF
--- a/context_pack/sources.go
+++ b/context_pack/sources.go
@@ -31,6 +31,11 @@ const (
 	// SourceAwsEcs — service↔repo OBSERVED from live AWS ECS. Cluster scope, Discovered. Sibling cloud
 	// connectors follow the cloud+service convention (gcp-cloudrun, azure-containerapps, …).
 	SourceAwsEcs SourceName = "aws-ecs"
+	// SourceAnsweredServiceMap — service↔repo CONFIRMED by a human in the dashboard: the durable
+	// "answered" layer. Org scope, Answered (SourceKind). Wins reconciliation over declared/observed
+	// and survives re-scans; app-server writes it when a user confirms or corrects an observed
+	// service's repo.
+	SourceAnsweredServiceMap SourceName = "answered-service-map"
 )
 
 // File is the on-disk filename a source's artifact uses: the source name + ".json". Deriving it

--- a/context_pack/sources_test.go
+++ b/context_pack/sources_test.go
@@ -9,6 +9,7 @@ var allSources = []SourceName{
 	SourceRepoCatalog,
 	SourceServiceRepoMap,
 	SourceAwsEcs,
+	SourceAnsweredServiceMap,
 }
 
 func TestSourceNamesUnique(t *testing.T) {


### PR DESCRIPTION
The **"answered" layer**: service↔repo mappings a user confirms or corrects in the dashboard. `SourceKind.Answered` already exists in the enum; this adds the matching **source name** so the mapping has a home.

It's its **own source** (not folded into `service-repo-map`) so:
- **merge-by-source** keeps it independent of declared (`service-repo-map`) and observed (`aws-ecs`) — writing an answer never clobbers the scanned layers;
- **reconciliation can rank it highest** (human > heuristic) and it **survives re-scans**.

Org scope; app-server writes it when the user confirms/corrects an observed service's repo. Test's `allSources` list updated; builds + tests pass.

First consumer: the app-server answered-mapping endpoint (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)