### PR TITLE
context_pack_enums: rename SourceKind.Discovered → Observed (single provenance vocabulary)

### DIFF
--- a/enums/context_pack_enums/source_kind.go
+++ b/enums/context_pack_enums/source_kind.go
@@ -7,7 +7,7 @@ package context_pack_enums
 type SourceKind uint
 
 const (
-	Discovered    SourceKind = iota + 1 // runner scan, deterministic
+	Observed      SourceKind = iota + 1 // runner scan / enumeration, deterministic
 	Fetched                             // live API snapshot (short TTL)
 	Answered                            // human-confirmed (durable)
 	Derived                             // structural extract / LLM
@@ -15,10 +15,10 @@ const (
 )
 
 var sourceKindToString = map[SourceKind]string{
-	Discovered: "discovered",
-	Fetched:    "fetched",
-	Answered:   "answered",
-	Derived:    "derived",
+	Observed: "observed",
+	Fetched:  "fetched",
+	Answered: "answered",
+	Derived:  "derived",
 }
 
 func (s SourceKind) String() string {


### PR DESCRIPTION
One provenance vocabulary. `Discovered` → **`Observed`** so `SourceKind` reads correctly for its scan/enumeration sources (aws-ecs running services, repo catalog) *and* matches the reconciliation's "observed" layer — letting `repoSource` be `SourceKind.String()` verbatim, with **no dashboard relabel**. Kinds are now **Observed / Fetched / Answered / Derived**.

Safe rename: numeric value unchanged (still `1`), so stored `context_packs` (bson uint) and the runner→server JSON wire (numeric) are unaffected — only `.String()` flips `"discovered"`→`"observed"`, which is surfaced solely via `repoSource`.

Consumers updated in paired PRs (app-server build/reconcile, runner aws-ecs, dashboard) — merge this first, then they bump drk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)