### PR TITLE
context_pack: SourceManagedDeployments — deployment.io's own managed deployments

### DIFF
--- a/context_pack/sources.go
+++ b/context_pack/sources.go
@@ -36,6 +36,13 @@ const (
 	// and survives re-scans; app-server writes it when a user confirms or corrects an observed
 	// service's repo.
 	SourceAnsweredServiceMap SourceName = "answered-service-map"
+	// SourceManagedDeployments — deployment.io's OWN managed deployments for the org, fetched from our
+	// system of record (the deployments collection). Org scope, Fetched (SourceKind). Grounds the agent
+	// on what deployment.io already runs, and is the authoritative layer reconciliation uses to
+	// RECOGNIZE an observed ECS service as already-managed — joining Deployment.EcsServiceArn ↔ the
+	// observed service's arn, then enriching to the real name/repo/environment instead of a
+	// rediscovered image-name row. Written server-side by app-server (it holds the Deployment records).
+	SourceManagedDeployments SourceName = "managed-deployments"
 )
 
 // File is the on-disk filename a source's artifact uses: the source name + ".json". Deriving it


### PR DESCRIPTION
## What

Adds a new `SourceName` const — `SourceManagedDeployments = "managed-deployments"` — an **Org-scoped, `Fetched`** context source: deployment.io's own managed `Deployment` records for the org, written server-side by app-server.

## Why

Two jobs, both **Phase A** of `PLAN_INFRA_ADOPTION.md`'s build sequence:
1. **Grounds the agent** on what deployment.io already runs (todo 2a — context of managed services).
2. It's the authoritative layer reconciliation uses to **recognize** an observed ECS service as already-managed — joining `Deployment.EcsServiceArn` ↔ the observed service's `arn` (runner #72) — enriching to the real name/repo/environment instead of a rediscovered `es-<id>` image-name row, and merging the Services table to one row per service.

`Fetched` is the acquisition mode (a snapshot from our system of record); reconciliation ranks it `managed` (top) separately.

## Scope

Const only. The app-server source builder + the kit `context_reconcile` `managed` layer are the follow-up PRs that consume it. `GOWORK=off` build + `context_pack` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)