### PR TITLE
deployment_enums: PreviewActive state for ephemeral preview idempotency

### DIFF
--- a/enums/deployment_enums/deletion_states.go
+++ b/enums/deployment_enums/deletion_states.go
@@ -6,6 +6,14 @@ const (
 	DeletionNotStarted DeletionState = iota
 	DeletionInProcess
 	DeletionDone
-	DeleteUndone     //this is when delete is aborted ex. when PR is reopened
+	DeleteUndone //this is when delete is aborted ex. when PR is reopened
+	// PreviewActive is a non-zero "alive" state for ephemeral preview environments.
+	// The zero value DeletionNotStarted is erased by `omitempty` on the DeletionState
+	// field, so a fresh active env stores no deletionState at all — which makes "active"
+	// impossible to express in a partial index. Ephemeral previews are created with
+	// PreviewActive instead so liveness is a stored, queryable ($eq) fact, enabling a
+	// partial-unique index (one active preview env per task) without touching omitempty
+	// or migrating existing data. Preview-only; permanent envs keep the zero convention.
+	PreviewActive
 	MaxDeletionState //always add new states before MaxDeletionState
 )


### PR DESCRIPTION
Adds a non-zero `PreviewActive` DeletionState so ephemeral preview envs can store a queryable 'alive' fact (the zero `DeletionNotStarted` is erased by `omitempty`). Enables a partial-unique index — one active preview env per task — with no omitempty change and no migration. Additive, preview-only.

Foundation for the EnsureV1 concurrency fix (kit + deployment-server follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)