### PR TITLE
Add GetSecretsManagerClientFromRegion for region-based clients

### DIFF
--- a/cloud_api_clients/aws.go
+++ b/cloud_api_clients/aws.go
@@ -256,6 +256,21 @@ func GetSecretsManagerClient(parameters map[string]interface{}) (*secretsmanager
 	return secretsManagerClient, nil
 }
 
+// GetSecretsManagerClientFromRegion builds a Secrets Manager client for an
+// explicit region, for callers (e.g. the Tasks agent runner) that have the
+// runner's region directly rather than a job's Region parameter.
+func GetSecretsManagerClientFromRegion(region string) (*secretsmanager.Client, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+	secretsManagerClient := secretsmanager.NewFromConfig(cfg, func(options *secretsmanager.Options) {
+		options.Region = region
+	})
+
+	return secretsManagerClient, nil
+}
+
 func GetServiceDiscoveryClient(parameters map[string]interface{}) (*servicediscovery.Client, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {


### PR DESCRIPTION
## What

Adds `GetSecretsManagerClientFromRegion(region string)` to `cloud_api_clients`, a region-based Secrets Manager client constructor.

## Why

The Tasks agent runner (deployment-runner) needs to read a customer-supplied Claude Code **subscription OAuth token** from the runner's own AWS Secrets Manager at agentbox spawn time. It has the runner's region directly (`RunnerData.RunnerRegion`) rather than a job `Region` parameter, so the existing `GetSecretsManagerClient(parameters)` (which reads `parameters_enums.Region`) doesn't fit.

This mirrors the existing region-based constructors already in this file (`GetEcsClientFromRegion`, `GetStsClient`, `GetAsgClient`).

Part of the Tasks subscription-auth (Phase 0) work; the consuming runner change is a follow-up PR that bumps this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)