### PR TITLE
Align the AWS SDK to core v1.43.3 / smithy v1.27.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.11
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.34.0
+	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
 	github.com/aws/aws-sdk-go-v2/service/acm v1.25.4
@@ -41,7 +41,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.20.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/aws/smithy-go v1.27.6 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect
 	github.com/stretchr/testify v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
-github.com/aws/aws-sdk-go-v2 v1.34.0/go.mod h1:JgstGg0JjWU1KpVJjD5H0y0yyAIpSdKEq556EI6yOOM=
+github.com/aws/aws-sdk-go-v2 v1.43.3 h1:XJIcfv8uDs2ukdQsoAC8/Ebu1ejxwzlayl2ZsiFns2A=
+github.com/aws/aws-sdk-go-v2 v1.43.3/go.mod h1:70vwSy16txshwG+g55WkpgPKDIByzHI8ccBsOteo3bQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 h1:lL7IfaFzngfx0ZwUGOZdsFFnQ5uLvR0hWqqhyE7Q9M8=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7/go.mod h1:QraP0UcVlQJsmHfioCrveWOC1nbiWUl3ej08h4mXWoc=
 github.com/aws/aws-sdk-go-v2/config v1.27.11 h1:f47rANd2LQEYHda2ddSCKYId18/8BhSRM4BULGmfgNA=
@@ -60,8 +60,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 h1:Jux+gDDyi1Lruk+KHF91tK2K
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4/go.mod h1:mUYPBhaF2lGiukDEjJX2BLRRKTmoUSitGDUgM4tRxak=
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 h1:cwIxeBttqPN3qkaAjcEcsh8NYr8n2HZPkcKgPAi1phU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.6/go.mod h1:FZf1/nKNEkHdGGJP/cI2MoIMquumuRK6ol3QQJNDxmw=
-github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
-github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.27.6 h1:0zjT8jgK3jbrTT7JJ3EE6JsMhX8JTrZ+f1sEndYDXrA=
+github.com/aws/smithy-go v1.27.6/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Part of a monorepo-wide AWS SDK alignment. One PR per repo.

## Why

`deployment-runner` had to move off core `v1.34.0` to add the Bedrock control-plane SDK for inference-profile discovery. **No version of `service/bedrock` is compatible with `v1.34.0`** — even the oldest checked requires more:

| bedrock | requires core | requires smithy |
|---|---|---|
| v1.40.0 | v1.37.0 | v1.22.5 |
| v1.49.1 | v1.39.6 | v1.23.2 |
| v1.66.3 (current) | v1.43.3 | v1.27.6 |

That left `deployment-runner` ahead of `kit`, `app-server`, and `deployment-runner-kit`, breaking the CLAUDE.md rule that all projects share dependency versions.

## Why align up rather than to the minimum

`v1.37.0` would be the smallest bump that admits the Bedrock module, but it needs exactly the same coordination across repos and lands on a version already about a year old — repeating the exercise soon. Paying the coordination cost once is better value.

`deployment-runner` already builds and passes its full suite on these versions, which is the best available evidence the jump is safe.

## Verification

`go.work` is precisely what masks this class of mismatch — which is why the rule exists — so everything was verified with **`GOWORK=off`**:

- standalone `go build ./...` — clean
- full `go test ./...` — clean

Only `go.mod` and `go.sum` change.

## Scope

- `kit`, `app-server`, `deployment-runner-kit` — this sweep
- `deployment-runner` — already on target
- `deployment-server` — no AWS dependencies, out of scope
- `deployment-runner-aws-controller` — **held back deliberately.** It sits on core `v1.30.3` (pre-existing drift, older than everyone). Bumping it forces its `go` directive `1.20 → 1.24`, which in turn requires its Dockerfile to move off `golang:1.20.0-buster` — and its runtime stage is `debian:buster-slim`, now EOL. That is a base-image migration, not a dependency bump, and does not belong in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
