### PR TITLE
Add the LLM provider/model/harness catalogue (single source of truth)

### DIFF
--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -1,0 +1,134 @@
+package llm_provider_enums
+
+// The catalogue: which (harness, model, provider) combinations are real.
+//
+// Held as THREE FLAT TABLES rather than one nested map[Harness]map[Model][]Provider,
+// because each table states an independently true fact and a valid combination
+// is their intersection:
+//
+//	harnessToModels    — claude-code cannot run gpt-5.5 whoever serves it
+//	modelToProviders   — Opus 4.8 is served by Anthropic and Bedrock, not OpenAI
+//	harnessToProviders — codex only ever talks to OpenAI
+//
+// A nested map would restate the same facts once per combination and drift
+// between rows. Worked example, and the question this package was built to
+// answer: "claude-code supports Opus 4.8, which could come from Anthropic
+// Direct or AWS Bedrock" —
+//
+//	ProvidersFor(ClaudeCode, ClaudeOpus48)
+//	  = modelToProviders[ClaudeOpus48]   // Direct, Subscription, Bedrock
+//	  ∩ harnessToProviders[ClaudeCode]   // Direct, Subscription, Bedrock, Vertex
+//	  = Direct, Subscription, Bedrock
+//
+// This is a STATIC LOOKUP TABLE, not state. Nothing here is persisted; it
+// says what is *possible*, never what a given org has configured. Whether an
+// org can actually use a provider is a separate question answered by its
+// credentials — and for Bedrock, by per-runner readiness.
+
+// harnessToModels lists the models each harness can run.
+//
+// opencode's entries are the same logical models as the others: the
+// "anthropic/" and "openai/" prefixes its CLI wants are a rendering of
+// (model, provider) at spawn, not part of the model's identity. That is the
+// point of keeping Model logical — see PLAN_provider_centric_llm_keys.md §3.3
+// and §4.1, where the prefix's second job (disambiguating the harness) is what
+// made stripping it dangerous until Harness became explicit.
+var harnessToModels = map[Harness][]Model{
+	ClaudeCode: {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48},
+	Codex:      {Gpt55, Gpt53Codex, Gpt54},
+	Opencode:   {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48, Gpt55},
+}
+
+// modelToProviders lists which providers can serve each model.
+//
+// AnthropicSubscription appears on the Claude models because the subscription
+// genuinely serves them — the restriction that only claude-code may use it is
+// a HARNESS constraint, expressed in harnessToProviders, not a model one.
+// Keeping those separate is what lets the intersection stay correct.
+var modelToProviders = map[Model][]Provider{
+	ClaudeHaiku45:  {AnthropicDirect, AnthropicSubscription, AWSBedrock},
+	ClaudeSonnet46: {AnthropicDirect, AnthropicSubscription, AWSBedrock},
+	ClaudeOpus48:   {AnthropicDirect, AnthropicSubscription, AWSBedrock},
+	Gpt55:          {OpenAIDirect},
+	Gpt53Codex:     {OpenAIDirect},
+	Gpt54:          {OpenAIDirect},
+}
+
+// harnessToProviders lists which providers each harness can authenticate to.
+//
+// The two constraints worth knowing, both enforced in deployment-runner today
+// and previously only discoverable by reading it:
+//
+//   - Codex is OpenAI-only. It has no Bedrock path at all.
+//   - Only claude-code may use AnthropicSubscription. maybeApplyClaudeSubscriptionAuth
+//     returns early for any other AGENT_TYPE, because a genuine `claude` CLI is
+//     what passes Anthropic's client-identity check; routing a subscription
+//     token through another agent is prohibited, not merely unsupported.
+//
+// GoogleVertex is listed for claude-code because the harness supports it, even
+// though no model above is served by it yet — the intersection keeps that from
+// ever being offered.
+var harnessToProviders = map[Harness][]Provider{
+	ClaudeCode: {AnthropicDirect, AnthropicSubscription, AWSBedrock, GoogleVertex},
+	Codex:      {OpenAIDirect},
+	Opencode:   {AnthropicDirect, AWSBedrock, OpenAIDirect},
+}
+
+// Models returns the models this harness can run.
+func (h Harness) Models() []Model { return harnessToModels[h] }
+
+// Providers returns the providers this harness can authenticate to.
+func (h Harness) Providers() []Provider { return harnessToProviders[h] }
+
+// Providers returns every provider that can serve this model, ignoring which
+// harness is asking. Use ProvidersFor when a harness is known.
+func (m Model) Providers() []Provider { return modelToProviders[m] }
+
+// Supports reports whether the harness can run the model at all.
+func (h Harness) Supports(m Model) bool {
+	for _, candidate := range harnessToModels[h] {
+		if candidate == m {
+			return true
+		}
+	}
+	return false
+}
+
+// ProvidersFor returns the providers that can serve this model through this
+// harness — the intersection of what serves the model and what the harness can
+// reach. Returns nil when the harness cannot run the model at all, so an empty
+// result always means "not possible", never "possible but unconfigured".
+//
+// Order follows modelToProviders so the result is deterministic; callers that
+// need a preferred provider should apply their own routing rather than relying
+// on position.
+func ProvidersFor(h Harness, m Model) []Provider {
+	if !h.Supports(m) {
+		return nil
+	}
+	reachable := make(map[Provider]bool, len(harnessToProviders[h]))
+	for _, p := range harnessToProviders[h] {
+		reachable[p] = true
+	}
+	var out []Provider
+	for _, p := range modelToProviders[m] {
+		if reachable[p] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// HarnessesFor returns every harness able to run the model. This is the
+// inverse of harnessToModels, and is what a model-first UI needs in order to
+// offer a harness choice once a model is picked — with the first entry as the
+// sensible default.
+func HarnessesFor(m Model) []Harness {
+	var out []Harness
+	for h := ClaudeCode; h < MaxHarness; h++ {
+		if h.Supports(m) {
+			out = append(out, h)
+		}
+	}
+	return out
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -36,16 +36,55 @@ func TestProvider_DisplayStringsUnchangedByTheRename(t *testing.T) {
 	}
 }
 
-func TestProvider_VendorCollapsesTheAuthModeFusion(t *testing.T) {
-	// The three ways of reaching Anthropic must agree on the vendor — that is
-	// the whole point of Vendor existing alongside the fused Provider.
-	for _, p := range []Provider{AnthropicDirect, AnthropicSubscription, AWSBedrock} {
-		if got := p.Vendor(); got != VendorAnthropic {
-			t.Errorf("%s.Vendor() = %v, want VendorAnthropic", p, got)
+func TestProvider_AuthModeRecoversTheFusedAxis(t *testing.T) {
+	// Provider fuses vendor-account and auth-mode for persistence reasons;
+	// AuthMode() is how callers get the distinction back without a migration.
+	cases := map[Provider]AuthMode{
+		AnthropicDirect:       AuthAPIKey,
+		OpenAIDirect:          AuthAPIKey,
+		AWSBedrock:            AuthCloudRole,
+		GoogleVertex:          AuthCloudRole,
+		AnthropicSubscription: AuthSubscription,
+	}
+	for p, want := range cases {
+		if got := p.AuthMode(); got != want {
+			t.Errorf("%s.AuthMode() = %v, want %v", p, got, want)
 		}
 	}
-	if got := OpenAIDirect.Vendor(); got != VendorOpenAI {
-		t.Errorf("OpenAIDirect.Vendor() = %v, want VendorOpenAI", got)
+	// StoresSecret drives whether "configured" can be a key-presence check.
+	// Bedrock and subscriptions hold nothing control-plane-side, which is
+	// exactly why HasCredentials special-cases them.
+	for _, p := range []Provider{AWSBedrock, GoogleVertex, AnthropicSubscription} {
+		if p.StoresSecret() {
+			t.Errorf("%s must not report storing a control-plane secret", p)
+		}
+	}
+	if !AnthropicDirect.StoresSecret() {
+		t.Error("AnthropicDirect stores an API key control-plane-side")
+	}
+}
+
+func TestModel_VendorIsAModelPropertyNotAProviderOne(t *testing.T) {
+	// Regression guard for a real conceptual error in an earlier revision,
+	// which hung Vendor off Provider and mapped AWSBedrock -> Anthropic.
+	// Bedrock serves Anthropic, Amazon, Google, Meta, Mistral and Qwen models;
+	// Vertex serves Claude as well as Gemini. A provider is a ROUTE to a model,
+	// so it has no vendor of its own.
+	if got := ClaudeOpus48.Vendor(); got != VendorAnthropic {
+		t.Errorf("ClaudeOpus48.Vendor() = %v, want VendorAnthropic", got)
+	}
+	if got := Gpt55.Vendor(); got != VendorOpenAI {
+		t.Errorf("Gpt55.Vendor() = %v, want VendorOpenAI", got)
+	}
+	// The same model keeps its vendor whichever provider serves it — the
+	// property the earlier design could not express.
+	for _, p := range ClaudeOpus48.Providers() {
+		_ = p // vendor is asked of the model, never of p
+	}
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		if m.Vendor() == VendorUnknown {
+			t.Errorf("model %s has no vendor", m)
+		}
 	}
 }
 

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -1,0 +1,202 @@
+package llm_provider_enums
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Persisted-value guards. These are the ones that matter most: values 1-4 are
+// in live MongoDB documents at Organization.ClaudeAuth.Provider, moved here
+// from kit/enums/claude_auth_enums with their numbering intact so that no data
+// migration was needed. Reordering for tidiness would silently reinterpret
+// every existing org's credential configuration.
+// ---------------------------------------------------------------------------
+
+func TestProvider_PersistedNumberingIsFrozen(t *testing.T) {
+	cases := map[Provider]uint{
+		AnthropicDirect:       1,
+		AWSBedrock:            2,
+		GoogleVertex:          3,
+		AnthropicSubscription: 4,
+	}
+	for p, want := range cases {
+		if uint(p) != want {
+			t.Errorf("provider %s = %d, want %d — this value is persisted in ClaudeAuth.Provider; renumbering reinterprets existing org documents", p, uint(p), want)
+		}
+	}
+}
+
+func TestProvider_DisplayStringsUnchangedByTheRename(t *testing.T) {
+	// String() feeds ProviderName on GET /organizations/current/claude-auth and
+	// is rendered in the dashboard. The Go identifier moved from Subscription to
+	// AnthropicSubscription; what a customer reads must not have moved with it.
+	if got := AnthropicSubscription.String(); got != "Claude Subscription" {
+		t.Errorf("AnthropicSubscription.String() = %q, want %q — user-visible text must survive the identifier rename", got, "Claude Subscription")
+	}
+	if got := AnthropicDirect.String(); got != "Anthropic Direct" {
+		t.Errorf("AnthropicDirect.String() = %q, want %q", got, "Anthropic Direct")
+	}
+}
+
+func TestProvider_VendorCollapsesTheAuthModeFusion(t *testing.T) {
+	// The three ways of reaching Anthropic must agree on the vendor — that is
+	// the whole point of Vendor existing alongside the fused Provider.
+	for _, p := range []Provider{AnthropicDirect, AnthropicSubscription, AWSBedrock} {
+		if got := p.Vendor(); got != VendorAnthropic {
+			t.Errorf("%s.Vendor() = %v, want VendorAnthropic", p, got)
+		}
+	}
+	if got := OpenAIDirect.Vendor(); got != VendorOpenAI {
+		t.Errorf("OpenAIDirect.Vendor() = %v, want VendorOpenAI", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Wire-format guards. These strings are stored in Task documents and accepted
+// by the MCP create_task tool; changing one orphans every Task holding it.
+// ---------------------------------------------------------------------------
+
+func TestModel_WireStringsAreStable(t *testing.T) {
+	cases := map[Model]string{
+		ClaudeHaiku45:  "claude-haiku-4-5",
+		ClaudeSonnet46: "claude-sonnet-4-6",
+		ClaudeOpus48:   "claude-opus-4-8",
+		Gpt55:          "gpt-5.5",
+		Gpt53Codex:     "gpt-5.3-codex",
+		Gpt54:          "gpt-5.4",
+	}
+	for m, want := range cases {
+		if got := m.String(); got != want {
+			t.Errorf("model %d String() = %q, want %q — this is the stored wire format", uint(m), got, want)
+		}
+		round, err := GetModel(want)
+		if err != nil || round != m {
+			t.Errorf("GetModel(%q) = %v, %v; want %d round-tripping", want, round, err, uint(m))
+		}
+	}
+}
+
+func TestHarness_ResolveDefaultsEmptyToClaudeCode(t *testing.T) {
+	// Tasks created before the agent type existed carry no AGENT_TYPE, and
+	// agentbox defaults an empty value to claude-code. Diverging here would
+	// route those Tasks to a different harness than the one that runs them.
+	h, err := ResolveHarness("")
+	if err != nil || h != ClaudeCode {
+		t.Errorf("ResolveHarness(\"\") = %v, %v; want ClaudeCode, nil", h, err)
+	}
+	if _, err := ResolveHarness("nonexistent"); err == nil {
+		t.Error("ResolveHarness must reject an unknown harness rather than defaulting it")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cross-table consistency. This is what makes the package a source of truth
+// rather than three lists that happen to sit together: a fact stated in one
+// table and contradicted in another is caught here rather than at task time.
+// ---------------------------------------------------------------------------
+
+func TestCatalog_EveryHarnessModelPairHasAtLeastOneProvider(t *testing.T) {
+	// A harness listing a model it can never actually be served is an offer the
+	// product cannot honour — the user picks it and the task fails at spawn.
+	for h := ClaudeCode; h < MaxHarness; h++ {
+		for _, m := range h.Models() {
+			if got := ProvidersFor(h, m); len(got) == 0 {
+				t.Errorf("%s lists model %s but no provider can serve it — harnessToProviders and modelToProviders disagree", h, m)
+			}
+		}
+	}
+}
+
+func TestCatalog_BedrockModelsAllHaveAFamilyToken(t *testing.T) {
+	// modelToProviders claiming AWSBedrock without a family token in
+	// modelToBedrockFamily means discovery has nothing to match on, and the
+	// logical id reaches Bedrock verbatim — the exact failure the live smoke
+	// test produced ("The provided model identifier is invalid").
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		onBedrock := false
+		for _, p := range m.Providers() {
+			if p == AWSBedrock {
+				onBedrock = true
+			}
+		}
+		if onBedrock && m.BedrockFamily() == "" {
+			t.Errorf("model %s lists AWSBedrock as a provider but has no Bedrock family token; discovery cannot resolve it", m)
+		}
+		if !onBedrock && m.BedrockFamily() != "" {
+			t.Errorf("model %s has a Bedrock family token but does not list AWSBedrock as a provider", m)
+		}
+	}
+}
+
+func TestCatalog_BedrockFamiliesAreFamiliesNotConcreteIDs(t *testing.T) {
+	// A version or revision baked in here would need a release of this module
+	// plus a bump in four repos per Bedrock model launch, and would fail at task
+	// time in between. Concrete ids carry dots and colons; families must not.
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		f := m.BedrockFamily()
+		for _, bad := range []string{".", ":"} {
+			if f != "" && contains(f, bad) {
+				t.Errorf("Bedrock family %q for %s looks like a concrete profile id; it must be a family token only", f, m)
+			}
+		}
+	}
+}
+
+func TestCatalog_SubscriptionIsClaudeCodeOnly(t *testing.T) {
+	// The runner refuses subscription auth for any harness but claude-code — a
+	// genuine `claude` CLI is what passes Anthropic's client-identity check, so
+	// this is prohibited rather than merely unsupported. If the table ever
+	// offered it elsewhere, the UI would present an option the runner drops.
+	for h := ClaudeCode; h < MaxHarness; h++ {
+		for _, p := range h.Providers() {
+			if p == AnthropicSubscription && h != ClaudeCode {
+				t.Errorf("%s lists AnthropicSubscription; only claude-code may use it", h)
+			}
+		}
+	}
+}
+
+func TestCatalog_TheWorkedExample(t *testing.T) {
+	// "claude-code supports Opus 4.8, which could be provided by Anthropic
+	// Direct or AWS Bedrock" — the question this package exists to answer.
+	got := ProvidersFor(ClaudeCode, ClaudeOpus48)
+	want := map[Provider]bool{AnthropicDirect: true, AnthropicSubscription: true, AWSBedrock: true}
+	if len(got) != len(want) {
+		t.Fatalf("ProvidersFor(ClaudeCode, ClaudeOpus48) = %v, want %d providers", got, len(want))
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected provider %s", p)
+		}
+	}
+	// Codex cannot run a Claude model regardless of provider.
+	if got := ProvidersFor(Codex, ClaudeOpus48); got != nil {
+		t.Errorf("ProvidersFor(Codex, ClaudeOpus48) = %v, want nil — codex cannot run Claude models", got)
+	}
+	// opencode can run Opus, but never via the subscription.
+	for _, p := range ProvidersFor(Opencode, ClaudeOpus48) {
+		if p == AnthropicSubscription {
+			t.Error("opencode must not be offered AnthropicSubscription")
+		}
+	}
+}
+
+func TestCatalog_HarnessesForIsTheInverseOfModels(t *testing.T) {
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		for _, h := range HarnessesFor(m) {
+			if !h.Supports(m) {
+				t.Errorf("HarnessesFor(%s) returned %s, which does not support it", m, h)
+			}
+		}
+	}
+	if len(HarnessesFor(Gpt55)) < 2 {
+		t.Error("gpt-5.5 should be runnable by both codex and opencode; the harness axis is the point")
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/enums/llm_provider_enums/harnesses.go
+++ b/enums/llm_provider_enums/harnesses.go
@@ -1,0 +1,58 @@
+package llm_provider_enums
+
+import "fmt"
+
+// Harness is the coding-agent CLI that runs a model — the third axis,
+// independent of provider and model.
+//
+// It is what agentbox receives as AGENT_TYPE, and the strings below are that
+// contract. An empty AGENT_TYPE defaults to claude-code inside agentbox, which
+// is why ResolveHarness maps "" rather than rejecting it: Tasks created before
+// Codex support have no stored agent type.
+//
+// Not persisted as an integer — Task documents store the string (String()
+// below), so the strings are the wire format and the numbering is free.
+type Harness uint
+
+const (
+	ClaudeCode Harness = iota + 1
+	Codex
+	Opencode
+
+	MaxHarness // always add harnesses before MaxHarness
+)
+
+var harnessToString = map[Harness]string{
+	ClaudeCode: "claude-code",
+	Codex:      "codex",
+	Opencode:   "opencode",
+}
+
+var stringToHarness = func() map[string]Harness {
+	m := make(map[string]Harness, len(harnessToString))
+	for k, v := range harnessToString {
+		m[v] = k
+	}
+	return m
+}()
+
+func (h Harness) String() string {
+	return harnessToString[h]
+}
+
+func (h Harness) IsValid() bool {
+	return h > 0 && h < MaxHarness
+}
+
+// ResolveHarness parses an AGENT_TYPE string. The empty string resolves to
+// ClaudeCode for backward compatibility with Tasks created before the agent
+// type existed — the same defaulting agentbox applies.
+func ResolveHarness(s string) (Harness, error) {
+	if s == "" {
+		return ClaudeCode, nil
+	}
+	if h, ok := stringToHarness[s]; ok {
+		return h, nil
+	}
+	return 0, fmt.Errorf("unknown agent harness %q", s)
+}

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -92,3 +92,56 @@ var modelToBedrockFamily = map[Model]string{
 func (m Model) BedrockFamily() string {
 	return modelToBedrockFamily[m]
 }
+
+// Vendor is who MAKES a model — a property of the model, never of the
+// provider serving it.
+//
+// ⚠️ This deliberately does not hang off Provider. AWSBedrock serves models
+// from Anthropic, Amazon, Google, Meta, Mistral, Qwen and others; GoogleVertex
+// serves Claude alongside Gemini. A provider is a route to a model, not a
+// statement about who built it, so asking "which vendor is AWSBedrock" has no
+// answer. An earlier revision of this package got that wrong.
+type Vendor uint
+
+const (
+	VendorUnknown Vendor = iota
+	VendorAnthropic
+	VendorOpenAI
+	VendorGoogle
+	VendorMeta
+	VendorMistral
+	VendorAmazon
+
+	MaxVendor // always add vendors before MaxVendor
+)
+
+var vendorToString = map[Vendor]string{
+	VendorAnthropic: "Anthropic",
+	VendorOpenAI:    "OpenAI",
+	VendorGoogle:    "Google",
+	VendorMeta:      "Meta",
+	VendorMistral:   "Mistral",
+	VendorAmazon:    "Amazon",
+}
+
+func (v Vendor) String() string {
+	return vendorToString[v]
+}
+
+// modelToVendor is only as long as the curated model list. Vendors beyond
+// Anthropic and OpenAI are declared above because Bedrock and opencode make
+// them reachable, not because a model here uses them yet.
+var modelToVendor = map[Model]Vendor{
+	ClaudeHaiku45:  VendorAnthropic,
+	ClaudeSonnet46: VendorAnthropic,
+	ClaudeOpus48:   VendorAnthropic,
+	Gpt55:          VendorOpenAI,
+	Gpt53Codex:     VendorOpenAI,
+	Gpt54:          VendorOpenAI,
+}
+
+// Vendor returns who makes this model, independent of how it is reached.
+// Use this for cost attribution or grouping — never Provider.
+func (m Model) Vendor() Vendor {
+	return modelToVendor[m]
+}

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -1,0 +1,94 @@
+package llm_provider_enums
+
+import "fmt"
+
+// Model is a LOGICAL model id — the model a user picks, independent of which
+// provider serves it or which harness runs it.
+//
+// ⚠️ LOGICAL, NEVER CONCRETE. A Model names "Claude Opus 4.8"; it does not
+// name `eu.anthropic.claude-opus-4-...-v1:0`. Provider-specific ids carry
+// versions, revisions and region prefixes that change as models ship and
+// differ per account — baking one in here would require a release of this
+// module plus a bump in four repos every time AWS publishes a revision, and
+// would fail at task time in between. The volatile half is resolved late:
+// see BedrockFamily below and the runner's ListInferenceProfiles discovery.
+//
+// Not persisted today — Task documents store the string id (String() below),
+// not the enum. Keep the strings stable for that reason; they are the wire
+// format.
+type Model uint
+
+const (
+	ClaudeHaiku45 Model = iota + 1
+	ClaudeSonnet46
+	ClaudeOpus48
+	Gpt55
+	Gpt53Codex
+	Gpt54
+
+	MaxModel // always add models before MaxModel
+)
+
+// modelToString is the WIRE FORMAT — what Task.Model holds, what the MCP
+// create_task tool accepts, and what the dashboard sends. Changing one of
+// these strings orphans every Task already storing it.
+var modelToString = map[Model]string{
+	ClaudeHaiku45:  "claude-haiku-4-5",
+	ClaudeSonnet46: "claude-sonnet-4-6",
+	ClaudeOpus48:   "claude-opus-4-8",
+	Gpt55:          "gpt-5.5",
+	Gpt53Codex:     "gpt-5.3-codex",
+	Gpt54:          "gpt-5.4",
+}
+
+var stringToModel = func() map[string]Model {
+	m := make(map[string]Model, len(modelToString))
+	for k, v := range modelToString {
+		m[v] = k
+	}
+	return m
+}()
+
+func (m Model) String() string {
+	return modelToString[m]
+}
+
+func (m Model) IsValid() bool {
+	return m > 0 && m < MaxModel
+}
+
+// GetModel parses a wire-format model id. Unknown ids are an error rather
+// than a zero value so callers must decide explicitly what to do with a model
+// this build does not know about — historically the lenient path let unknown
+// ids through to the agent, which is still valid, but it should be a choice.
+func GetModel(s string) (Model, error) {
+	if m, ok := stringToModel[s]; ok {
+		return m, nil
+	}
+	return 0, fmt.Errorf("unknown model id %q", s)
+}
+
+// modelToBedrockFamily maps a logical model to the Bedrock "family token"
+// shared by every concrete inference profile for it.
+//
+// It deliberately stops at the family. A live run turned up two id shapes in
+// one account — `anthropic.claude-sonnet-5` and
+// `anthropic.claude-sonnet-4-5-20250929-v1:0` — so the version and revision
+// come from discovery, not from here. This map only needs to be right about
+// which family a model belongs to, which changes rarely.
+//
+// Absent entry = not available on Bedrock (the GPT models). Keep in step with
+// modelToProviders: a model listing AWSBedrock as a provider needs a family
+// here, and catalog_test.go enforces exactly that.
+var modelToBedrockFamily = map[Model]string{
+	ClaudeHaiku45:  "claude-haiku-4",
+	ClaudeSonnet46: "claude-sonnet-4",
+	ClaudeOpus48:   "claude-opus-4",
+}
+
+// BedrockFamily returns the Bedrock family token for a model, or "" when the
+// model is not served by Bedrock. The caller matches this against the ids
+// returned by bedrock:ListInferenceProfiles for its own region.
+func (m Model) BedrockFamily() string {
+	return modelToBedrockFamily[m]
+}

--- a/enums/llm_provider_enums/providers.go
+++ b/enums/llm_provider_enums/providers.go
@@ -83,42 +83,60 @@ func (p Provider) IsValid() bool {
 	return p > 0 && p < MaxProvider
 }
 
-// Vendor returns the underlying vendor for a provider, collapsing the
-// auth-mode distinction that Provider fuses. AnthropicDirect,
-// AnthropicSubscription and AWSBedrock all resolve to Anthropic models, so
-// anything reasoning about "whose model is this" (cost attribution, model
-// availability) wants this rather than the raw provider.
-func (p Provider) Vendor() Vendor {
+// AuthMode returns HOW this provider is authenticated to.
+//
+// This recovers the axis PLAN_provider_centric_llm_keys.md §2 wanted split out
+// of Provider — without renumbering anything. Auth mode is DERIVED from the
+// provider rather than stored beside it, so the persisted values above stay
+// untouched while callers that genuinely need the distinction (which fields a
+// settings card renders, whether a credential is stored at all) can still ask.
+//
+// Deliberately NOT a stored field: a provider fully determines its auth mode,
+// so persisting both would create a pair that can disagree.
+func (p Provider) AuthMode() AuthMode {
 	switch p {
-	case AnthropicDirect, AnthropicSubscription, AWSBedrock:
-		return VendorAnthropic
-	case OpenAIDirect:
-		return VendorOpenAI
-	case GoogleVertex:
-		return VendorGoogle
+	case AnthropicDirect, OpenAIDirect:
+		return AuthAPIKey
+	case AWSBedrock, GoogleVertex:
+		return AuthCloudRole
+	case AnthropicSubscription:
+		return AuthSubscription
 	}
-	return VendorUnknown
+	return AuthUnknown
 }
 
-// Vendor is who actually makes the model, independent of how it is reached.
-// Not persisted — derived from Provider.
-type Vendor uint
+// AuthMode is how a provider is authenticated to — the axis fused into
+// Provider for persistence reasons, recoverable via Provider.AuthMode().
+type AuthMode uint
 
 const (
-	VendorUnknown Vendor = iota
-	VendorAnthropic
-	VendorOpenAI
-	VendorGoogle
+	AuthUnknown AuthMode = iota
+	// AuthAPIKey — a secret held control-plane-side, encrypted at rest.
+	AuthAPIKey
+	// AuthCloudRole — no stored secret at all; the runner assumes a role in the
+	// customer's own cloud and vends short-lived credentials at spawn.
+	AuthCloudRole
+	// AuthSubscription — an OAuth token held in the CUSTOMER's secret store and
+	// read runner-side, never transiting the control plane.
+	AuthSubscription
 
-	MaxVendor
+	MaxAuthMode
 )
 
-var vendorToString = map[Vendor]string{
-	VendorAnthropic: "Anthropic",
-	VendorOpenAI:    "OpenAI",
-	VendorGoogle:    "Google",
+var authModeToString = map[AuthMode]string{
+	AuthAPIKey:       "API key",
+	AuthCloudRole:    "Cloud IAM role",
+	AuthSubscription: "Subscription",
 }
 
-func (v Vendor) String() string {
-	return vendorToString[v]
+func (a AuthMode) String() string {
+	return authModeToString[a]
+}
+
+// StoresSecret reports whether configuring this provider means holding a
+// credential control-plane-side. False for Bedrock/Vertex (role-assumed) and
+// for subscriptions (token lives in the customer's own secret store), which is
+// why "configured" cannot be a key-presence check for those.
+func (p Provider) StoresSecret() bool {
+	return p.AuthMode() == AuthAPIKey
 }

--- a/enums/llm_provider_enums/providers.go
+++ b/enums/llm_provider_enums/providers.go
@@ -1,0 +1,124 @@
+// Package llm_provider_enums is the single source of truth for the three
+// axes of running a coding agent: which PROVIDER serves a model, which MODEL
+// is being run, and which agent HARNESS runs it — plus the relationships
+// between them.
+//
+// It lives in deployment-runner-kit because that is the only module every
+// repo imports (kit, app-server, deployment-server and deployment-runner all
+// depend on it, while deployment-runner cannot import kit). Anything defined
+// here is visible to the control plane and the runner alike, which is what
+// stops the two drifting — the failure mode this package exists to end. See
+// the duplicated CLAUDE_AUTH_MODE / CLAUDE_CODE_USE_BEDROCK literals in
+// deployment-runner for what the alternative looks like.
+package llm_provider_enums
+
+// Provider identifies WHOSE models are being called and over which API.
+//
+// ⚠️ PERSISTED — DO NOT RENUMBER. Values 1-4 are stored in live MongoDB
+// documents at Organization.ClaudeAuth.Provider. This enum was moved here
+// from kit/enums/claude_auth_enums with its numbering intact precisely so no
+// data migration was needed; reordering for tidiness would silently
+// reinterpret every existing org's credential configuration. Append only,
+// before MaxProvider.
+//
+// ⚠️ NOT EVERY VALUE IS PERSISTED. 1-4 appear in ClaudeAuth.Provider.
+// OpenAIDirect does not appear anywhere: OpenAIAuth has no Provider field and
+// infers its provider from the presence of an API key, so nothing writes 5.
+// It exists for the catalogue below, which needs to reason about OpenAI even
+// though the org document never names it. Do not read "no org has provider 5"
+// as a bug. PLAN_provider_centric_llm_keys.md §3 makes this symmetric by
+// replacing both structs with LLMConfig.Providers[].
+//
+// ⚠️ AnthropicSubscription IS AN AUTH MODE WEARING A PROVIDER'S CLOTHES.
+// It is Anthropic-the-vendor reached with an OAuth subscription token rather
+// than an API key, so it is not a sibling of AnthropicDirect in the way
+// AWSBedrock is. Keeping the two fused is a deliberate, recorded decision
+// (see the plan §2 vs §11.3): splitting auth mode into its own axis would
+// have forced a migration of the persisted values above for a distinction
+// only the settings UI actually cares about, and the UI can render one
+// "Anthropic" card with a mode toggle regardless. The rename from the former
+// "Subscription" at least makes the fusion visible instead of hidden.
+type Provider uint
+
+const (
+	AnthropicDirect Provider = iota + 1 // 1 — Anthropic API key
+	AWSBedrock                          // 2 — runner-assumed IAM role, no stored secret
+	GoogleVertex                        // 3 — reserved, not wired
+	// AnthropicSubscription is the customer's own Claude Code subscription
+	// (Pro/Max) OAuth token. No credential is held control-plane-side: the
+	// token lives only in the customer's own AWS Secrets Manager and is read
+	// by the runner at agentbox spawn. claude-code only — the runner refuses
+	// it for other harnesses, which harnessToProviders below encodes.
+	AnthropicSubscription // 4
+	// OpenAIDirect is catalogue-only; see the note above.
+	OpenAIDirect // 5
+
+	MaxProvider // always add providers before MaxProvider
+)
+
+// providerToString values are USER-VISIBLE. They are surfaced as
+// ProviderName on GET /organizations/current/claude-auth and rendered in the
+// dashboard, so they are deliberately unchanged by the Go-level rename of
+// Subscription -> AnthropicSubscription. Renaming an identifier should not
+// silently alter what a customer reads.
+var providerToString = map[Provider]string{
+	AnthropicDirect:       "Anthropic Direct",
+	AWSBedrock:            "AWS Bedrock",
+	GoogleVertex:          "Google Vertex",
+	AnthropicSubscription: "Claude Subscription",
+	OpenAIDirect:          "OpenAI Direct",
+}
+
+func (p Provider) String() string {
+	return providerToString[p]
+}
+
+func (p Provider) IsZero() bool {
+	return p == 0
+}
+
+// IsValid reports whether p names a declared provider. The zero value means
+// "unconfigured" and is not valid.
+func (p Provider) IsValid() bool {
+	return p > 0 && p < MaxProvider
+}
+
+// Vendor returns the underlying vendor for a provider, collapsing the
+// auth-mode distinction that Provider fuses. AnthropicDirect,
+// AnthropicSubscription and AWSBedrock all resolve to Anthropic models, so
+// anything reasoning about "whose model is this" (cost attribution, model
+// availability) wants this rather than the raw provider.
+func (p Provider) Vendor() Vendor {
+	switch p {
+	case AnthropicDirect, AnthropicSubscription, AWSBedrock:
+		return VendorAnthropic
+	case OpenAIDirect:
+		return VendorOpenAI
+	case GoogleVertex:
+		return VendorGoogle
+	}
+	return VendorUnknown
+}
+
+// Vendor is who actually makes the model, independent of how it is reached.
+// Not persisted — derived from Provider.
+type Vendor uint
+
+const (
+	VendorUnknown Vendor = iota
+	VendorAnthropic
+	VendorOpenAI
+	VendorGoogle
+
+	MaxVendor
+)
+
+var vendorToString = map[Vendor]string{
+	VendorAnthropic: "Anthropic",
+	VendorOpenAI:    "OpenAI",
+	VendorGoogle:    "Google",
+}
+
+func (v Vendor) String() string {
+	return vendorToString[v]
+}


### PR DESCRIPTION
Single source of truth for the three axes of running a coding agent — **provider**, **model**, **harness** — and the relationships between them.

**PR 1 of 3.** kit and app-server follow once this is released and their `go.mod` is bumped; they can't compile against it before then.

## Why here

`deployment-runner-kit` is the only module every repo imports. `deployment-runner` cannot import `kit`, which is exactly why `CLAUDE_AUTH_MODE` and `CLAUDE_CODE_USE_BEDROCK` are today duplicated across repos with *"change them in both or it silently stops working"* comments, and why `bedrockModelFamilies` had to be maintained separately from kit's `claudeModels`. This ends that class of drift.

## Provider is moved, not redefined

Taken from `kit/enums/claude_auth_enums` **with its numbering intact**. Values 1–4 are persisted at `Organization.ClaudeAuth.Provider`, and `bson` sees a `uint` either way — so **no data migration at all**.

The alternative (a fresh enum with clean numbering, per the plan's §3/§6) needed a full dual-read backfill to reach the same end state, and would have left two `Provider` enums in which a bare `2` means Bedrock in one and OpenAI in the other.

| Value | Name | Persisted? |
|---|---|---|
| 1 | AnthropicDirect | ✅ ClaudeAuth.Provider |
| 2 | AWSBedrock | ✅ |
| 3 | GoogleVertex | ✅ (reserved) |
| 4 | **AnthropicSubscription** (was `Subscription`) | ✅ |
| 5 | **OpenAIDirect** (new) | ❌ catalogue-only |

`OpenAIDirect` is deliberately never written: `OpenAIAuth` has no `Provider` field and infers its provider from key presence. Documented in the enum so *"no org has provider 5"* doesn't read as a bug. Phase 1's `LLMConfig.Providers[]` makes it symmetric.

**Display strings are unchanged.** `String()` feeds `ProviderName` to the dashboard; renaming a Go identifier must not alter what a customer reads. A test pins that.

## On keeping auth mode fused

`AnthropicSubscription` is an auth mode wearing a provider's clothes, which §2 of the providers plan calls out. Keeping them fused is a **recorded decision, not an oversight**: splitting would force the migration above for a distinction only the settings UI cares about, and the UI can render one "Anthropic" card with a mode toggle regardless.

`Provider.AuthMode()` recovers the axis anyway — **derived, not stored**, so the persisted values stay untouched and there is no second field that can disagree with the first:

| Provider | AuthMode |
|---|---|
| AnthropicDirect, OpenAIDirect | `AuthAPIKey` |
| AWSBedrock, GoogleVertex | `AuthCloudRole` |
| AnthropicSubscription | `AuthSubscription` |

`StoresSecret()` falls out of it, and is the rule behind the special cases already in `HasCredentials`: Bedrock, Vertex and subscriptions hold nothing control-plane-side, so "configured" cannot be a key-presence check for them.

## Vendor belongs to the model

Review caught a genuine error in the first commit: `Provider.Vendor()` mapped `AWSBedrock → Anthropic`. That is false — **Bedrock is a transport, not a vendor**, serving Anthropic, Amazon, Google, Meta, Mistral and Qwen models; `GoogleVertex` likewise serves Claude alongside Gemini.

A provider is a *route* to a model, so it has no vendor of its own. `Vendor` now hangs off `Model`, where a model keeps its vendor whichever provider serves it — the property the old shape could not express. A test guards against it drifting back.

## The catalogue: three flat tables, not one nested map

```go
harnessToModels    // claude-code cannot run gpt-5.5 whoever serves it
modelToProviders   // Opus 4.8 comes from Anthropic or Bedrock, not OpenAI
harnessToProviders // codex only ever talks to OpenAI
```

Each states an independently true fact; a valid combination is their **intersection**. A nested `map[Harness]map[Model][]Provider` would restate the same facts once per combination and drift between rows.

Your worked example, which is a test:

```go
ProvidersFor(ClaudeCode, ClaudeOpus48)
  = modelToProviders[ClaudeOpus48]   // Direct, Subscription, Bedrock
  ∩ harnessToProviders[ClaudeCode]   // Direct, Subscription, Bedrock, Vertex
  = Direct, Subscription, Bedrock
```

Note `AnthropicSubscription` sits in `modelToProviders` (the subscription genuinely serves those models) while the claude-code-only restriction lives in `harnessToProviders`. Keeping them separate is what makes the intersection correct — and it captures a rule the runner enforces today but that was previously only discoverable by reading `maybeApplyClaudeSubscriptionAuth`.

## Model stays logical

`Model` names *Opus 4.8*; it never names `eu.anthropic.claude-opus-4-...-v1:0`. Only the **family token** lives here — version, revision and region come from `ListInferenceProfiles` discovery (runner #91). So a Bedrock model launch needs no release of this module, which is precisely the failure the live smoke test produced.

## Tests: 12, cross-table consistency mutation-checked

The consistency checks are what make this a source of truth rather than three lists that happen to sit together. Each was verified to fail when the fact it guards is broken:

| Mutation | Caught by |
|---|---|
| opencode offered `AnthropicSubscription` | `SubscriptionIsClaudeCodeOnly` |
| codex offered a Claude model | `EveryHarnessModelPairHasAtLeastOneProvider` |
| Bedrock claimed with no family token | `BedrockModelsAllHaveAFamilyToken` |

Plus frozen persisted numbering, stable wire strings with round-tripping, and empty-`AGENT_TYPE` defaulting to claude-code (matching agentbox).

## Scope

Additive only — nothing imports it yet, so this cannot break anything on merge. The curated model set is **unchanged** (no Sonnet 5 / Opus 5 added): that's a product decision, not a refactor, and is now a one-line change in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
