### PR TITLE
Add Amazon Nova Pro to the catalogue

### DIFF
--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -36,7 +36,7 @@ package llm_provider_enums
 var harnessToModels = map[Harness][]Model{
 	ClaudeCode: {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48},
 	Codex:      {Gpt55, Gpt53Codex, Gpt54},
-	Opencode:   {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48, Gpt55},
+	Opencode:   {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48, Gpt55, NovaPro},
 }
 
 // modelToProviders lists which providers can serve each model.
@@ -52,6 +52,11 @@ var modelToProviders = map[Model][]Provider{
 	Gpt55:          {OpenAIDirect},
 	Gpt53Codex:     {OpenAIDirect},
 	Gpt54:          {OpenAIDirect},
+	// Bedrock-only: Amazon does not offer Nova through a direct API, so this
+	// is the first model whose single provider is a cloud route rather than
+	// its vendor. claude-code and codex cannot run it — harnessToModels keeps
+	// it to opencode.
+	NovaPro: {AWSBedrock},
 }
 
 // harnessToProviders lists which providers each harness can authenticate to.

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -36,7 +36,7 @@ package llm_provider_enums
 var harnessToModels = map[Harness][]Model{
 	ClaudeCode: {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48},
 	Codex:      {Gpt55, Gpt53Codex, Gpt54},
-	Opencode:   {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48, Gpt55, NovaPro},
+	Opencode:   {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48, Gpt55, NovaProV1},
 }
 
 // modelToProviders lists which providers can serve each model.
@@ -56,7 +56,7 @@ var modelToProviders = map[Model][]Provider{
 	// is the first model whose single provider is a cloud route rather than
 	// its vendor. claude-code and codex cannot run it — harnessToModels keeps
 	// it to opencode.
-	NovaPro: {AWSBedrock},
+	NovaProV1: {AWSBedrock},
 }
 
 // harnessToProviders lists which providers each harness can authenticate to.

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -101,6 +101,7 @@ func TestModel_WireStringsAreStable(t *testing.T) {
 		Gpt55:          "gpt-5.5",
 		Gpt53Codex:     "gpt-5.3-codex",
 		Gpt54:          "gpt-5.4",
+		NovaPro:        "nova-pro",
 	}
 	for m, want := range cases {
 		if got := m.String(); got != want {
@@ -215,6 +216,38 @@ func TestCatalog_TheWorkedExample(t *testing.T) {
 		if p == AnthropicSubscription {
 			t.Error("opencode must not be offered AnthropicSubscription")
 		}
+	}
+}
+
+func TestCatalog_NovaIsBedrockOnlyAndOpencodeOnly(t *testing.T) {
+	// Nova is the first model that exercises the axes rather than riding on
+	// the old claude-code/codex symmetry, so its shape is worth pinning.
+
+	// Bedrock-only: Amazon offers no direct API for Nova, so its single
+	// provider is a cloud ROUTE rather than its vendor. That distinction is
+	// exactly why Vendor hangs off Model and not Provider.
+	got := NovaPro.Providers()
+	if len(got) != 1 || got[0] != AWSBedrock {
+		t.Errorf("NovaPro.Providers() = %v, want exactly [AWSBedrock]", got)
+	}
+	if NovaPro.Vendor() != VendorAmazon {
+		t.Errorf("NovaPro.Vendor() = %v, want VendorAmazon", NovaPro.Vendor())
+	}
+
+	// Only opencode can run it — claude-code speaks the Anthropic API and
+	// codex is OpenAI-only, so neither can drive a Nova model however it is
+	// reached.
+	harnesses := HarnessesFor(NovaPro)
+	if len(harnesses) != 1 || harnesses[0] != Opencode {
+		t.Errorf("HarnessesFor(NovaPro) = %v, want exactly [Opencode]", harnesses)
+	}
+	if ClaudeCode.Supports(NovaPro) || Codex.Supports(NovaPro) {
+		t.Error("neither claude-code nor codex can run a Nova model")
+	}
+
+	// And it must be resolvable through opencode, or offering it is a lie.
+	if len(ProvidersFor(Opencode, NovaPro)) == 0 {
+		t.Error("no provider can serve NovaPro through opencode")
 	}
 }
 

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -1,6 +1,9 @@
 package llm_provider_enums
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // ---------------------------------------------------------------------------
 // Persisted-value guards. These are the ones that matter most: values 1-4 are
@@ -101,7 +104,7 @@ func TestModel_WireStringsAreStable(t *testing.T) {
 		Gpt55:          "gpt-5.5",
 		Gpt53Codex:     "gpt-5.3-codex",
 		Gpt54:          "gpt-5.4",
-		NovaPro:        "nova-pro",
+		NovaProV1:      "nova-pro-v1",
 	}
 	for m, want := range cases {
 		if got := m.String(); got != want {
@@ -145,11 +148,11 @@ func TestCatalog_EveryHarnessModelPairHasAtLeastOneProvider(t *testing.T) {
 	}
 }
 
-func TestCatalog_BedrockModelsAllHaveAFamilyToken(t *testing.T) {
-	// modelToProviders claiming AWSBedrock without a family token in
-	// modelToBedrockFamily means discovery has nothing to match on, and the
-	// logical id reaches Bedrock verbatim — the exact failure the live smoke
-	// test produced ("The provided model identifier is invalid").
+func TestCatalog_BedrockModelsAllHaveAProfilePrefix(t *testing.T) {
+	// modelToProviders claiming AWSBedrock without a prefix means discovery has
+	// nothing to match on, and the logical id reaches Bedrock verbatim — the
+	// exact failure the live smoke test produced ("The provided model
+	// identifier is invalid").
 	for m := ClaudeHaiku45; m < MaxModel; m++ {
 		onBedrock := false
 		for _, p := range m.Providers() {
@@ -157,25 +160,76 @@ func TestCatalog_BedrockModelsAllHaveAFamilyToken(t *testing.T) {
 				onBedrock = true
 			}
 		}
-		if onBedrock && m.BedrockFamily() == "" {
-			t.Errorf("model %s lists AWSBedrock as a provider but has no Bedrock family token; discovery cannot resolve it", m)
+		if onBedrock && m.BedrockProfilePrefix() == "" {
+			t.Errorf("model %s lists AWSBedrock but has no profile prefix; discovery cannot resolve it", m)
 		}
-		if !onBedrock && m.BedrockFamily() != "" {
-			t.Errorf("model %s has a Bedrock family token but does not list AWSBedrock as a provider", m)
+		if !onBedrock && m.BedrockProfilePrefix() != "" {
+			t.Errorf("model %s has a profile prefix but does not list AWSBedrock as a provider", m)
 		}
 	}
 }
 
-func TestCatalog_BedrockFamiliesAreFamiliesNotConcreteIDs(t *testing.T) {
-	// A version or revision baked in here would need a release of this module
-	// plus a bump in four repos per Bedrock model launch, and would fail at task
-	// time in between. Concrete ids carry dots and colons; families must not.
+// ---------------------------------------------------------------------------
+// THE RULE FOR ADDING A MODEL: every entry carries a version, and every entry
+// is unique — as a wire id and as a Bedrock profile prefix.
+//
+// This is not tidiness. Matching against inference profiles is Contains(), so
+// an id or prefix that does not pin a version can match a NEIGHBOURING
+// version's profile and silently run the wrong model: no error, no log line,
+// resolution looking entirely successful.
+// ---------------------------------------------------------------------------
+
+func TestCatalog_EveryModelIdCarriesAVersion(t *testing.T) {
+	// A digit is the enforceable proxy for "has a version": claude-opus-4-8,
+	// gpt-5.5, nova-pro-v1 all qualify; a bare "nova-pro" does not. The first
+	// draft of the Nova entry was exactly that, and would have matched any
+	// future Nova Pro v2 profile the moment AWS published one.
 	for m := ClaudeHaiku45; m < MaxModel; m++ {
-		f := m.BedrockFamily()
-		for _, bad := range []string{".", ":"} {
-			if f != "" && contains(f, bad) {
-				t.Errorf("Bedrock family %q for %s looks like a concrete profile id; it must be a family token only", f, m)
-			}
+		if !strings.ContainsAny(m.String(), "0123456789") {
+			t.Errorf("model id %q carries no version; a versionless id can match a future version's profile", m)
+		}
+	}
+}
+
+func TestCatalog_ModelIdsAndPrefixesAreUnique(t *testing.T) {
+	ids := map[string]Model{}
+	prefixes := map[string]Model{}
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		if prev, dup := ids[m.String()]; dup {
+			t.Errorf("wire id %q is used by both %d and %d", m.String(), uint(prev), uint(m))
+		}
+		ids[m.String()] = m
+
+		p := m.BedrockProfilePrefix()
+		if p == "" {
+			continue
+		}
+		if prev, dup := prefixes[p]; dup {
+			t.Errorf("Bedrock prefix %q is shared by %s and %s; both would resolve to the same profile", p, prev, m)
+		}
+		prefixes[p] = m
+	}
+}
+
+func TestCatalog_BedrockPrefixPinsTheModelVersion(t *testing.T) {
+	// The prefix must pin the same model AND version the wire id names, leaving
+	// only the date and revision to discovery — those genuinely vary per region
+	// and account.
+	//
+	// Regression guard for a real bug: claude-sonnet-4-6 carried the prefix
+	// "claude-sonnet-4", which Contains-matches
+	// eu.anthropic.claude-sonnet-4-5-20250929-v1:0. A Sonnet 4.6 task would
+	// have silently run Sonnet 4.5.
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		p := m.BedrockProfilePrefix()
+		if p == "" {
+			continue
+		}
+		if p != m.String() {
+			t.Errorf("model %s has Bedrock prefix %q; it must pin the same version as the wire id. If a model genuinely needs a different prefix, that is a deliberate decision — document it and relax this assertion for that entry only", m, p)
+		}
+		if !strings.ContainsAny(p, "0123456789") {
+			t.Errorf("Bedrock prefix %q for %s carries no version; it can match a neighbouring version's profile", p, m)
 		}
 	}
 }
@@ -226,27 +280,27 @@ func TestCatalog_NovaIsBedrockOnlyAndOpencodeOnly(t *testing.T) {
 	// Bedrock-only: Amazon offers no direct API for Nova, so its single
 	// provider is a cloud ROUTE rather than its vendor. That distinction is
 	// exactly why Vendor hangs off Model and not Provider.
-	got := NovaPro.Providers()
+	got := NovaProV1.Providers()
 	if len(got) != 1 || got[0] != AWSBedrock {
-		t.Errorf("NovaPro.Providers() = %v, want exactly [AWSBedrock]", got)
+		t.Errorf("NovaProV1.Providers() = %v, want exactly [AWSBedrock]", got)
 	}
-	if NovaPro.Vendor() != VendorAmazon {
-		t.Errorf("NovaPro.Vendor() = %v, want VendorAmazon", NovaPro.Vendor())
+	if NovaProV1.Vendor() != VendorAmazon {
+		t.Errorf("NovaProV1.Vendor() = %v, want VendorAmazon", NovaProV1.Vendor())
 	}
 
 	// Only opencode can run it — claude-code speaks the Anthropic API and
 	// codex is OpenAI-only, so neither can drive a Nova model however it is
 	// reached.
-	harnesses := HarnessesFor(NovaPro)
+	harnesses := HarnessesFor(NovaProV1)
 	if len(harnesses) != 1 || harnesses[0] != Opencode {
-		t.Errorf("HarnessesFor(NovaPro) = %v, want exactly [Opencode]", harnesses)
+		t.Errorf("HarnessesFor(NovaProV1) = %v, want exactly [Opencode]", harnesses)
 	}
-	if ClaudeCode.Supports(NovaPro) || Codex.Supports(NovaPro) {
+	if ClaudeCode.Supports(NovaProV1) || Codex.Supports(NovaProV1) {
 		t.Error("neither claude-code nor codex can run a Nova model")
 	}
 
 	// And it must be resolvable through opencode, or offering it is a lie.
-	if len(ProvidersFor(Opencode, NovaPro)) == 0 {
+	if len(ProvidersFor(Opencode, NovaProV1)) == 0 {
 		t.Error("no provider can serve NovaPro through opencode")
 	}
 }

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -25,11 +25,11 @@ const (
 	Gpt55
 	Gpt53Codex
 	Gpt54
-	// NovaPro is Amazon's own model and the first entry here that is
+	// NovaProV1 is Amazon's own model and the first entry here that is
 	// Bedrock-ONLY — there is no direct API for it. It is also the first
 	// non-Anthropic, non-OpenAI model, which is what the vendor axis was
 	// added for.
-	NovaPro
+	NovaProV1
 
 	MaxModel // always add models before MaxModel
 )
@@ -44,7 +44,7 @@ var modelToString = map[Model]string{
 	Gpt55:          "gpt-5.5",
 	Gpt53Codex:     "gpt-5.3-codex",
 	Gpt54:          "gpt-5.4",
-	NovaPro:        "nova-pro",
+	NovaProV1:      "nova-pro-v1",
 }
 
 var stringToModel = func() map[string]Model {
@@ -86,21 +86,33 @@ func GetModel(s string) (Model, error) {
 // Absent entry = not available on Bedrock (the GPT models). Keep in step with
 // modelToProviders: a model listing AWSBedrock as a provider needs a family
 // here, and catalog_test.go enforces exactly that.
-var modelToBedrockFamily = map[Model]string{
-	ClaudeHaiku45:  "claude-haiku-4",
-	ClaudeSonnet46: "claude-sonnet-4",
-	ClaudeOpus48:   "claude-opus-4",
-	// Matches ids like eu.amazon.nova-pro-v1:0 — no vendor segment, same as
-	// the Claude families above, since the region and vendor parts come from
-	// the profile id that discovery returns.
-	NovaPro: "nova-pro",
+// modelToBedrockProfilePrefix maps a logical model to the VERSION-PINNED
+// prefix shared by every concrete inference profile for that exact model.
+//
+// ⚠️ IT MUST PIN THE VERSION. An earlier revision used loose family tokens —
+// "claude-sonnet-4" for claude-sonnet-4-6 — and matching is Contains(), so it
+// also matched `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`. A task asking
+// for Sonnet 4.6 would have silently run Sonnet 4.5: no error, no log line,
+// resolution looking entirely successful. Only the date and revision may be
+// left to discovery, because those genuinely vary per region and account. The
+// model VERSION is not something to guess at.
+//
+// Absent entry = not available on Bedrock (the GPT models). Kept in step with
+// modelToProviders and enforced by catalog_test.go.
+var modelToBedrockProfilePrefix = map[Model]string{
+	ClaudeHaiku45:  "claude-haiku-4-5",
+	ClaudeSonnet46: "claude-sonnet-4-6",
+	ClaudeOpus48:   "claude-opus-4-8",
+	// Matches ids like eu.amazon.nova-pro-v1:0 — the vendor and region
+	// segments come from the profile id that discovery returns.
+	NovaProV1: "nova-pro-v1",
 }
 
-// BedrockFamily returns the Bedrock family token for a model, or "" when the
-// model is not served by Bedrock. The caller matches this against the ids
-// returned by bedrock:ListInferenceProfiles for its own region.
-func (m Model) BedrockFamily() string {
-	return modelToBedrockFamily[m]
+// BedrockProfilePrefix returns the version-pinned prefix for a model, or ""
+// when the model is not served by Bedrock. The caller matches this against the
+// ids returned by bedrock:ListInferenceProfiles for its own region.
+func (m Model) BedrockProfilePrefix() string {
+	return modelToBedrockProfilePrefix[m]
 }
 
 // Vendor is who MAKES a model — a property of the model, never of the
@@ -148,7 +160,7 @@ var modelToVendor = map[Model]Vendor{
 	Gpt55:          VendorOpenAI,
 	Gpt53Codex:     VendorOpenAI,
 	Gpt54:          VendorOpenAI,
-	NovaPro:        VendorAmazon,
+	NovaProV1:      VendorAmazon,
 }
 
 // Vendor returns who makes this model, independent of how it is reached.

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -25,6 +25,11 @@ const (
 	Gpt55
 	Gpt53Codex
 	Gpt54
+	// NovaPro is Amazon's own model and the first entry here that is
+	// Bedrock-ONLY — there is no direct API for it. It is also the first
+	// non-Anthropic, non-OpenAI model, which is what the vendor axis was
+	// added for.
+	NovaPro
 
 	MaxModel // always add models before MaxModel
 )
@@ -39,6 +44,7 @@ var modelToString = map[Model]string{
 	Gpt55:          "gpt-5.5",
 	Gpt53Codex:     "gpt-5.3-codex",
 	Gpt54:          "gpt-5.4",
+	NovaPro:        "nova-pro",
 }
 
 var stringToModel = func() map[string]Model {
@@ -84,6 +90,10 @@ var modelToBedrockFamily = map[Model]string{
 	ClaudeHaiku45:  "claude-haiku-4",
 	ClaudeSonnet46: "claude-sonnet-4",
 	ClaudeOpus48:   "claude-opus-4",
+	// Matches ids like eu.amazon.nova-pro-v1:0 — no vendor segment, same as
+	// the Claude families above, since the region and vendor parts come from
+	// the profile id that discovery returns.
+	NovaPro: "nova-pro",
 }
 
 // BedrockFamily returns the Bedrock family token for a model, or "" when the
@@ -138,6 +148,7 @@ var modelToVendor = map[Model]Vendor{
 	Gpt55:          VendorOpenAI,
 	Gpt53Codex:     VendorOpenAI,
 	Gpt54:          VendorOpenAI,
+	NovaPro:        VendorAmazon,
 }
 
 // Vendor returns who makes this model, independent of how it is reached.


### PR DESCRIPTION
Unblocks the Bedrock smoke test.

## Why Nova specifically

Testing Bedrock via **opencode with an Amazon model** routes around Anthropic's first-use gate — which turned out to be a *reviewed use-case submission*, not a toggle, and is still pending. Nova lets `InvokeModel` be proven end to end without waiting on it.

## It's the first model that actually exercises the three axes

Everything before it rode on the old claude-code/codex symmetry, where harness, vendor and provider happened to line up.

| Property | Nova |
|---|---|
| Providers | **`AWSBedrock` only** — Amazon offers no direct API |
| Vendor | `VendorAmazon` — first non-Anthropic/non-OpenAI model |
| Harnesses | **opencode only** — claude-code speaks the Anthropic API, codex is OpenAI-only |

Its single provider is a cloud **route** rather than its vendor, which is precisely the distinction that made `Vendor` a property of `Model` instead of `Provider`.

## Verification

Every existing cross-table guard passed unchanged on the new entry — notably that a Bedrock-serving model has a family token, and that a harness never lists a model no provider can serve. A Nova-specific test pins the three properties above.

## Follow-ons

- kit: `amazon-bedrock/nova-pro` in `opencodeModels` (needs this released first — opencode's model validation is an allowlist, unlike claude-code's lenient path)
- runner + deployment-server: B3, already open