### PR TITLE
Document and guard the agent-type priority order

### DIFF
--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -428,3 +428,30 @@ func TestRuntimeResolvedProvidersHaveDiscoveryInput(t *testing.T) {
 		}
 	}
 }
+
+func TestAgentTypesFor_PriorityOrder(t *testing.T) {
+	// The first entry is the default agent for a model, and it comes from the
+	// ENUM DECLARATION ORDER. That makes the declaration load-bearing in a way
+	// nothing else would catch: inserting a new agent type in the middle would
+	// silently re-route every model it can run, with no compile error.
+	//
+	// The rule being encoded is "prefer the specialised agent over the
+	// general-purpose one".
+	cases := map[Model]AgentType{
+		ClaudeOpus48:   ClaudeCode, // opencode can run it too
+		ClaudeSonnet46: ClaudeCode,
+		ClaudeHaiku45:  ClaudeCode,
+		Gpt55:          Codex,    // opencode can run it too
+		NovaProV1:      Opencode, // the only option
+	}
+	for m, want := range cases {
+		got := AgentTypesFor(m)
+		if len(got) == 0 {
+			t.Errorf("AgentTypesFor(%s) is empty", m)
+			continue
+		}
+		if got[0] != want {
+			t.Errorf("AgentTypesFor(%s)[0] = %s, want %s — the specialised agent must outrank the general-purpose one", m, got[0], want)
+		}
+	}
+}


### PR DESCRIPTION
`AgentTypesFor` returns agent types in priority order, and the **first entry becomes a model's default agent**.

That order comes from the **enum declaration**, which makes the declaration load-bearing in a way nothing would otherwise catch. Inserting a new agent type in the middle — alphabetically, say — would silently re-route every model it can run: no compile error, no obviously related test failure.

The rule being encoded is *prefer the specialised agent over the general-purpose one*:

| Model | Capable | Default |
|---|---|---|
| `claude-opus-4-8` | claude-code, opencode | claude-code |
| `gpt-5.5` | codex, opencode | codex |
| `nova-pro-v1` | opencode | opencode |

Now stated in the doc comment and pinned by a test, rather than being an emergent property of where someone happened to add a constant.

Prompted by a good question — whether `AgentTypeForModel` should return an array, since several agents can run the same model. The list already exists here (`AgentTypesFor`); what was missing was any statement that its *order* means something.