### PR TITLE
Add stable provider keys for storage and URLs

### DIFF
--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -455,3 +455,69 @@ func TestAgentTypesFor_PriorityOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestProviderKeys_AreStable(t *testing.T) {
+	// These are PERSISTED as the keys of LLMConfig.Providers and appear in API
+	// paths. Changing one silently orphans an org's credentials for that
+	// provider — the entry survives under the old key and is simply never read
+	// again, so the org looks unconfigured with nothing to explain why.
+	//
+	// Same contract as the model wire ids: append, never rename.
+	want := map[Provider]string{
+		AnthropicDirect:       "anthropic-direct",
+		AWSBedrock:            "aws-bedrock",
+		GoogleVertex:          "google-vertex",
+		AnthropicSubscription: "anthropic-subscription",
+		OpenAIDirect:          "openai-direct",
+	}
+	for p, k := range want {
+		if got := p.Key(); got != k {
+			t.Errorf("%s.Key() = %q, want %q — changing a key orphans stored credentials", p, got, k)
+		}
+		back, err := ProviderFromKey(k)
+		if err != nil || back != p {
+			t.Errorf("ProviderFromKey(%q) = %v, %v; want %s round-tripping", k, back, err, p)
+		}
+	}
+}
+
+func TestProviderKeys_AreDistinctFromDisplayStrings(t *testing.T) {
+	// The whole point of a separate vocabulary: String() is user-facing and must
+	// stay free to change, so no key may equal a display string. If they ever
+	// coincide, someone will "simplify" by using one for both and couple a copy
+	// edit to stored data.
+	for p := AnthropicDirect; p < MaxProvider; p++ {
+		if p.Key() == "" {
+			t.Errorf("%s has no storage key", p)
+			continue
+		}
+		if p.Key() == p.String() {
+			t.Errorf("%s: key and display string are both %q; they must stay separate vocabularies", p, p.Key())
+		}
+		if strings.ContainsAny(p.Key(), " .$") {
+			t.Errorf("%s key %q contains a character that is awkward in a Mongo path or URL", p, p.Key())
+		}
+	}
+}
+
+func TestProviderKeys_AreUnique(t *testing.T) {
+	seen := map[string]Provider{}
+	for p := AnthropicDirect; p < MaxProvider; p++ {
+		k := p.Key()
+		if prev, dup := seen[k]; dup {
+			t.Errorf("key %q is shared by %s and %s; one org entry would serve both", k, prev, p)
+		}
+		seen[k] = p
+	}
+}
+
+func TestProviderFromKey_RejectsUnknown(t *testing.T) {
+	// A corrupted document or a provider from a newer build must surface, not
+	// read as "unconfigured".
+	if _, err := ProviderFromKey("not-a-provider"); err == nil {
+		t.Error("an unknown key must be an error, not a zero Provider")
+	}
+	if _, err := ProviderFromKey(""); err == nil {
+		t.Error("an empty key must be an error")
+	}
+}

--- a/enums/llm_provider_enums/providers.go
+++ b/enums/llm_provider_enums/providers.go
@@ -12,6 +12,8 @@
 // deployment-runner for what the alternative looks like.
 package llm_provider_enums
 
+import "fmt"
+
 // Provider identifies WHOSE models are being called and over which API.
 //
 // ⚠️ PERSISTED — DO NOT RENUMBER. Values 1-4 are stored in live MongoDB
@@ -164,4 +166,53 @@ func (p Provider) ResolvesModelIDAtRuntime() bool {
 		return true
 	}
 	return false
+}
+
+// providerKey is the STABLE, machine-facing identifier for a provider.
+//
+// ⚠️ NOT the same as String(), and deliberately so. String() is user-facing
+// display text rendered in the dashboard; these are storage and URL keys. If
+// they were the same value, a copy edit — "Claude Subscription" reading better
+// as "Anthropic Subscription", say — would orphan every stored document and
+// break every URL. Keeping them separate lets display text change freely.
+//
+// ⚠️ THESE ARE PERSISTED as the keys of Organization.LLMConfig.Providers, and
+// appear in API paths (/llm-providers/{key}). Changing one silently orphans an
+// org's credentials for that provider — the entry survives under the old key
+// and is simply never read again. Treat them like the model wire ids: append,
+// never rename. TestProviderKeys_AreStable pins each one.
+//
+// Chosen over the numeric enum values for readability: an incident is easier
+// to work through against "llmConfig.providers.aws-bedrock" than
+// "llmConfig.providers.2".
+var providerKey = map[Provider]string{
+	AnthropicDirect:       "anthropic-direct",
+	AWSBedrock:            "aws-bedrock",
+	GoogleVertex:          "google-vertex",
+	AnthropicSubscription: "anthropic-subscription",
+	OpenAIDirect:          "openai-direct",
+}
+
+var keyToProvider = func() map[string]Provider {
+	m := make(map[string]Provider, len(providerKey))
+	for p, k := range providerKey {
+		m[k] = p
+	}
+	return m
+}()
+
+// Key returns the stable storage/URL identifier for a provider.
+func (p Provider) Key() string {
+	return providerKey[p]
+}
+
+// ProviderFromKey parses a stored or URL-supplied provider key. An unknown key
+// is an error rather than a zero value: it means either a provider this build
+// does not know, or a corrupted document, and both deserve to surface rather
+// than silently read as "unconfigured".
+func ProviderFromKey(key string) (Provider, error) {
+	if p, ok := keyToProvider[key]; ok {
+		return p, nil
+	}
+	return 0, fmt.Errorf("unknown provider key %q", key)
 }


### PR DESCRIPTION
`LLMConfig` stores providers in a map, and the key should be readable — working an incident against `llmConfig.providers.aws-bedrock` beats `llmConfig.providers.2`.

## Why not `String()`

Those are **user-facing display strings**, rendered in the dashboard and returned as `ProviderName`. They were preserved unchanged through the `Harness → AgentType` rename precisely so a Go-level edit couldn't alter what a customer reads.

Using them as keys couples stored data to copy: renaming *"Claude Subscription"* → *"Anthropic Subscription"* for clarity would orphan every document. They also contain spaces, giving query paths like `"llmConfig.providers.AWS Bedrock.apiKey"` — legal, but not something you type confidently at 2am.

## The contract

Same as the model wire ids: **append, never rename.**

Changing a key silently orphans an org's credentials for that provider — the entry survives under the old key and is simply never read again, so the org looks unconfigured with nothing to explain why.

Three tests pin it:

| Test | Catches |
|---|---|
| `AreStable` | exact values, with round-tripping |
| `AreUnique` | two providers sharing a key |
| `AreDistinctFromDisplayStrings` | someone later "simplifying" by using one value for both |

The third is the one that protects the decision rather than the data.

## A free choice, as it happens

The numeric values were frozen only because `ClaudeAuth.Provider` persisted them. Nothing persists them once `LLMConfig` lands and the old structs go — so picking the readable option costs nothing.

`ProviderFromKey` errors on an unknown key rather than returning a zero `Provider`: a corrupted document or a provider from a newer build should surface, not read as "unconfigured".