### PR TITLE
Carry the agent provider as a typed param, not an env marker

### DIFF
--- a/enums/llm_provider_enums/agent_env.go
+++ b/enums/llm_provider_enums/agent_env.go
@@ -1,0 +1,56 @@
+package llm_provider_enums
+
+// The env-var contract between the control plane and the agent container.
+//
+// These names and values are a CROSS-REPO WIRE CONTRACT. deployment-server
+// puts them into a Job's AgentEnvVars; deployment-runner reads them to decide
+// what to inject; agentbox reads some of them directly. They live here because
+// deployment-runner-kit is the only module all three can import — the runner
+// cannot import kit, which is why it previously carried its own copies with a
+// comment reading "change them in both or subscription auth silently stops
+// engaging and every task quietly falls back to the API key". That comment
+// described a bug waiting to happen; this removes the possibility.
+//
+// ⚠️ THE VALUES ARE THE CONTRACT, not the identifiers. Renaming a Go constant
+// is free and compile-checked. Changing a string here changes what a deployed
+// runner is looking for, so a mismatched deploy fails silently: the marker is
+// simply never recognised and the task falls back rather than erroring.
+const (
+	// EnvSubscriptionAuthMode marks an org as using its own Claude subscription.
+	// NON-SECRET: the OAuth token itself lives in the customer's own Secrets
+	// Manager and is read runner-side, never transiting the control plane.
+	//
+	// The name still says CLAUDE because it is claude-code's own concept and the
+	// value is deployed; the Go identifier no longer references the deleted
+	// ClaudeAuth struct.
+	EnvSubscriptionAuthMode = "CLAUDE_AUTH_MODE"
+
+	// SubscriptionAuthModeValue is what EnvSubscriptionAuthMode is set to. Any
+	// other value means "not subscription mode".
+	SubscriptionAuthModeValue = "subscription"
+
+	// EnvBedrockMode marks an org as reaching models through AWS Bedrock, and
+	// tells the runner to assume dr-bedrock-role and inject short-lived
+	// credentials at spawn.
+	//
+	// It does double duty: claude-code reads this exact variable as its own
+	// Bedrock switch, which is why the runner keeps it for claude-code and
+	// strips it for every other agent — the name is misleading for opencode,
+	// which cannot use it.
+	EnvBedrockMode = "CLAUDE_CODE_USE_BEDROCK"
+
+	// BedrockModeValue is what EnvBedrockMode is set to.
+	BedrockModeValue = "1"
+)
+
+// IsSubscriptionAuthMode reports whether an injected env bundle marks
+// subscription auth. Provided so callers compare through one place rather than
+// each writing their own string comparison against the value above.
+func IsSubscriptionAuthMode(env map[string]string) bool {
+	return env[EnvSubscriptionAuthMode] == SubscriptionAuthModeValue
+}
+
+// IsBedrockMode reports whether an injected env bundle marks Bedrock.
+func IsBedrockMode(env map[string]string) bool {
+	return env[EnvBedrockMode] == BedrockModeValue
+}

--- a/enums/llm_provider_enums/agent_env.go
+++ b/enums/llm_provider_enums/agent_env.go
@@ -1,97 +1,50 @@
 package llm_provider_enums
 
-// The env-var contract between the control plane and the agent container.
+// The env-var contract for spawning an agent container.
 //
-// These names and values are a CROSS-REPO WIRE CONTRACT. deployment-server
-// puts them into a Job's AgentEnvVars; deployment-runner reads them to decide
-// what to inject; agentbox reads some of them directly. They live here because
-// deployment-runner-kit is the only module all three can import — the runner
-// cannot import kit, which is why it previously carried its own copies with a
-// comment reading "change them in both or subscription auth silently stops
-// engaging and every task quietly falls back to the API key". That comment
-// described a bug waiting to happen; this removes the possibility.
+// ⚠️ ONLY TWO KINDS OF THING BELONG IN AN AGENT'S ENV:
 //
-// ⚠️ THE VALUES ARE THE CONTRACT, not the identifiers. Renaming a Go constant
-// is free and compile-checked. Changing a string here changes what a deployed
-// runner is looking for, so a mismatched deploy fails silently: the marker is
-// simply never recognised and the task falls back rather than erroring.
+//  1. secrets and settings the agent itself consumes (ANTHROPIC_API_KEY,
+//     AWS_* credentials);
+//  2. a CLI's own documented switches, whose names we do not choose.
+//
+// A decision *we* make about how to run the agent is NEITHER. It travels as a
+// typed job parameter — parameters_enums.AgentProvider, the sibling of
+// AgentType — because that is a control signal for the runner, not payload for
+// the container.
+//
+// This distinction used to be blurred: the provider was encoded as a
+// CLAUDE_AUTH_MODE string, stuffed into the same bundle as the API key, and
+// then read back and deleted by the runner. That round trip threw away the
+// type, put a non-secret in the secrets channel, and created a contract whose
+// breakage was silent — a name mismatch meant subscription auth simply never
+// engaged and every task fell back to metered API-key billing, with no error
+// and no failing task. Reading Provider directly removes the marker, the round
+// trip, and that whole failure mode.
 const (
-	// EnvAgentAuthMode marks an org as authenticating with its own subscription
-	// rather than an API key. NON-SECRET: the OAuth token itself lives in the
-	// customer's own Secrets Manager and is read runner-side, never transiting
-	// the control plane.
+	// EnvBedrockMode is claude-code's OWN switch for routing through Bedrock —
+	// its name and value are Anthropic's, not ours, which is exactly why this
+	// one legitimately lives in the container env.
 	//
-	// AGENT-NEUTRAL BY DESIGN. Unlike EnvBedrockMode below, this marker is
-	// purely ours — the runner consumes it and deletes it, so no CLI ever sees
-	// it and the name was never constrained. It composes with AGENT_TYPE:
-	// AGENT_TYPE=claude-code + AGENT_AUTH_MODE=subscription today, and
-	// AGENT_TYPE=codex + AGENT_AUTH_MODE=subscription when a Codex
-	// subscription lands — no second marker, no second code path deciding
-	// which one to read.
-	EnvAgentAuthMode = "AGENT_AUTH_MODE"
-
-	// EnvAgentAuthModeLegacy is the name this marker had while it was
-	// Claude-specific.
-	//
-	// TRANSITIONAL — remove one release after every runner is upgraded.
-	// Readers must accept BOTH: a control plane sending the new name to a
-	// runner that only knows the old one would silently stop engaging
-	// subscription auth and quietly fall back to the API key — metered billing,
-	// no error, tasks still passing. Accepting both costs one map lookup and
-	// removes the coordinated-deploy requirement entirely.
-	EnvAgentAuthModeLegacy = "CLAUDE_AUTH_MODE"
-
-	// SubscriptionAuthModeValue is what EnvAgentAuthMode is set to. Any other
-	// value means "not subscription mode" — the comparison is exact, so a
-	// near-miss must not engage subscription auth.
-	SubscriptionAuthModeValue = "subscription"
-
-	// EnvBedrockMode marks an org as reaching models through AWS Bedrock, and
-	// tells the runner to assume dr-bedrock-role and inject short-lived
-	// credentials at spawn.
-	//
-	// It does double duty: claude-code reads this exact variable as its own
-	// Bedrock switch, which is why the runner keeps it for claude-code and
-	// strips it for every other agent — the name is misleading for opencode,
-	// which cannot use it.
+	// The runner WRITES it (see ApplyBedrockMode); nothing on our side reads it
+	// back. Derive from Provider instead.
 	EnvBedrockMode = "CLAUDE_CODE_USE_BEDROCK"
 
 	// BedrockModeValue is what EnvBedrockMode is set to.
 	BedrockModeValue = "1"
 )
 
-// IsSubscriptionAuthMode reports whether an injected env bundle marks
-// subscription auth. Provided so callers compare through one place rather than
-// each writing their own string comparison against the value above.
-func IsSubscriptionAuthMode(env map[string]string) bool {
-	if env[EnvAgentAuthMode] == SubscriptionAuthModeValue {
-		return true
-	}
-	// Legacy name, for jobs created before the rename or picked up by a runner
-	// mid-upgrade. Drop with EnvAgentAuthModeLegacy.
-	return env[EnvAgentAuthModeLegacy] == SubscriptionAuthModeValue
-}
-
-// ConsumeSubscriptionAuthMode reports whether env marks subscription auth and
-// removes the marker, so it never reaches the agent container. It is our
-// control-plane signal, not a CLI's — the runner acts on it by injecting the
-// OAuth token, and the CLI has no use for it.
+// ApplyBedrockMode sets claude-code's Bedrock switch when — and only when — the
+// org's provider routes through Bedrock AND the agent is claude-code. No other
+// agent understands this variable: codex ignores it, and opencode selects
+// Bedrock through its own "amazon-bedrock/…" model id (see OpencodeModelID).
 //
-// Detect-and-strip is ONE call on purpose. Two accepted names means a
-// hand-written `delete` eventually removes one and leaks the other, and a
-// leaked marker is invisible: the task runs fine, the variable is just sitting
-// in the container. Callers that only want to test the bundle without mutating
-// it should use IsSubscriptionAuthMode.
-func ConsumeSubscriptionAuthMode(env map[string]string) bool {
-	on := IsSubscriptionAuthMode(env)
-	// Unconditional: a marker set to some other value is still ours, and still
-	// must not reach the container.
-	delete(env, EnvAgentAuthMode)
-	delete(env, EnvAgentAuthModeLegacy)
-	return on
-}
-
-// IsBedrockMode reports whether an injected env bundle marks Bedrock.
-func IsBedrockMode(env map[string]string) bool {
-	return env[EnvBedrockMode] == BedrockModeValue
+// Write-if-needed, deliberately, rather than the strip-if-wrong-agent it
+// replaces. Removing a variable that should not be there fails open — miss one
+// path and it leaks into the container; adding one only where it belongs cannot
+// leak at all.
+func ApplyBedrockMode(env map[string]string, p Provider, agentType AgentType) {
+	if p == AWSBedrock && agentType == ClaudeCode {
+		env[EnvBedrockMode] = BedrockModeValue
+	}
 }

--- a/enums/llm_provider_enums/agent_env.go
+++ b/enums/llm_provider_enums/agent_env.go
@@ -22,29 +22,37 @@ package llm_provider_enums
 // and no failing task. Reading Provider directly removes the marker, the round
 // trip, and that whole failure mode.
 const (
-	// EnvBedrockMode is claude-code's OWN switch for routing through Bedrock —
-	// its name and value are Anthropic's, not ours, which is exactly why this
-	// one legitimately lives in the container env.
+	// EnvClaudeCodeUseBedrock is claude-code's OWN switch for routing through
+	// Bedrock. Its name and value are Anthropic's, not ours — which is why this
+	// one legitimately lives in the container env, and why the identifier names
+	// the CLI rather than the concept. There is no general "Bedrock mode" env
+	// var to abstract over: codex has no equivalent, and opencode selects
+	// Bedrock through its model id. A neutral name here would invite handing a
+	// second agent a variable it does not understand.
 	//
-	// The runner WRITES it (see ApplyBedrockMode); nothing on our side reads it
-	// back. Derive from Provider instead.
-	EnvBedrockMode = "CLAUDE_CODE_USE_BEDROCK"
+	// The runner WRITES it (see ApplyClaudeCodeUseBedrock); nothing on our side
+	// reads it back. Derive from Provider instead.
+	EnvClaudeCodeUseBedrock = "CLAUDE_CODE_USE_BEDROCK"
 
-	// BedrockModeValue is what EnvBedrockMode is set to.
-	BedrockModeValue = "1"
+	// ClaudeCodeUseBedrockValue is what EnvClaudeCodeUseBedrock is set to.
+	// Meaningless on its own — it exists only to name that variable's value,
+	// which is what binds it to claude-code too.
+	ClaudeCodeUseBedrockValue = "1"
 )
 
-// ApplyBedrockMode sets claude-code's Bedrock switch when — and only when — the
-// org's provider routes through Bedrock AND the agent is claude-code. No other
-// agent understands this variable: codex ignores it, and opencode selects
-// Bedrock through its own "amazon-bedrock/…" model id (see OpencodeModelID).
+// ApplyClaudeCodeUseBedrock sets claude-code's Bedrock switch when — and only
+// when — the org's provider routes through Bedrock AND the agent is
+// claude-code. No other agent understands this variable: codex ignores it, and
+// opencode selects Bedrock through its own "amazon-bedrock/…" model id (see
+// OpencodeModelID).
 //
-// Write-if-needed, deliberately, rather than the strip-if-wrong-agent it
-// replaces. Removing a variable that should not be there fails open — miss one
-// path and it leaks into the container; adding one only where it belongs cannot
-// leak at all.
-func ApplyBedrockMode(env map[string]string, p Provider, agentType AgentType) {
+// It keeps taking agentType despite being claude-code-specific, so callers can
+// call it unconditionally and let it refuse. That is the point: it replaces a
+// strip-if-wrong-agent step, and removing a variable that should not be there
+// fails open — miss one path and it leaks into the container. Pushing the
+// agent check back to the caller would reintroduce exactly that.
+func ApplyClaudeCodeUseBedrock(env map[string]string, p Provider, agentType AgentType) {
 	if p == AWSBedrock && agentType == ClaudeCode {
-		env[EnvBedrockMode] = BedrockModeValue
+		env[EnvClaudeCodeUseBedrock] = ClaudeCodeUseBedrockValue
 	}
 }

--- a/enums/llm_provider_enums/agent_env.go
+++ b/enums/llm_provider_enums/agent_env.go
@@ -16,17 +16,34 @@ package llm_provider_enums
 // runner is looking for, so a mismatched deploy fails silently: the marker is
 // simply never recognised and the task falls back rather than erroring.
 const (
-	// EnvSubscriptionAuthMode marks an org as using its own Claude subscription.
-	// NON-SECRET: the OAuth token itself lives in the customer's own Secrets
-	// Manager and is read runner-side, never transiting the control plane.
+	// EnvAgentAuthMode marks an org as authenticating with its own subscription
+	// rather than an API key. NON-SECRET: the OAuth token itself lives in the
+	// customer's own Secrets Manager and is read runner-side, never transiting
+	// the control plane.
 	//
-	// The name still says CLAUDE because it is claude-code's own concept and the
-	// value is deployed; the Go identifier no longer references the deleted
-	// ClaudeAuth struct.
-	EnvSubscriptionAuthMode = "CLAUDE_AUTH_MODE"
+	// AGENT-NEUTRAL BY DESIGN. Unlike EnvBedrockMode below, this marker is
+	// purely ours — the runner consumes it and deletes it, so no CLI ever sees
+	// it and the name was never constrained. It composes with AGENT_TYPE:
+	// AGENT_TYPE=claude-code + AGENT_AUTH_MODE=subscription today, and
+	// AGENT_TYPE=codex + AGENT_AUTH_MODE=subscription when a Codex
+	// subscription lands — no second marker, no second code path deciding
+	// which one to read.
+	EnvAgentAuthMode = "AGENT_AUTH_MODE"
 
-	// SubscriptionAuthModeValue is what EnvSubscriptionAuthMode is set to. Any
-	// other value means "not subscription mode".
+	// EnvAgentAuthModeLegacy is the name this marker had while it was
+	// Claude-specific.
+	//
+	// TRANSITIONAL — remove one release after every runner is upgraded.
+	// Readers must accept BOTH: a control plane sending the new name to a
+	// runner that only knows the old one would silently stop engaging
+	// subscription auth and quietly fall back to the API key — metered billing,
+	// no error, tasks still passing. Accepting both costs one map lookup and
+	// removes the coordinated-deploy requirement entirely.
+	EnvAgentAuthModeLegacy = "CLAUDE_AUTH_MODE"
+
+	// SubscriptionAuthModeValue is what EnvAgentAuthMode is set to. Any other
+	// value means "not subscription mode" — the comparison is exact, so a
+	// near-miss must not engage subscription auth.
 	SubscriptionAuthModeValue = "subscription"
 
 	// EnvBedrockMode marks an org as reaching models through AWS Bedrock, and
@@ -47,7 +64,31 @@ const (
 // subscription auth. Provided so callers compare through one place rather than
 // each writing their own string comparison against the value above.
 func IsSubscriptionAuthMode(env map[string]string) bool {
-	return env[EnvSubscriptionAuthMode] == SubscriptionAuthModeValue
+	if env[EnvAgentAuthMode] == SubscriptionAuthModeValue {
+		return true
+	}
+	// Legacy name, for jobs created before the rename or picked up by a runner
+	// mid-upgrade. Drop with EnvAgentAuthModeLegacy.
+	return env[EnvAgentAuthModeLegacy] == SubscriptionAuthModeValue
+}
+
+// ConsumeSubscriptionAuthMode reports whether env marks subscription auth and
+// removes the marker, so it never reaches the agent container. It is our
+// control-plane signal, not a CLI's — the runner acts on it by injecting the
+// OAuth token, and the CLI has no use for it.
+//
+// Detect-and-strip is ONE call on purpose. Two accepted names means a
+// hand-written `delete` eventually removes one and leaks the other, and a
+// leaked marker is invisible: the task runs fine, the variable is just sitting
+// in the container. Callers that only want to test the bundle without mutating
+// it should use IsSubscriptionAuthMode.
+func ConsumeSubscriptionAuthMode(env map[string]string) bool {
+	on := IsSubscriptionAuthMode(env)
+	// Unconditional: a marker set to some other value is still ours, and still
+	// must not reach the container.
+	delete(env, EnvAgentAuthMode)
+	delete(env, EnvAgentAuthModeLegacy)
+	return on
 }
 
 // IsBedrockMode reports whether an injected env bundle marks Bedrock.

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -521,3 +521,42 @@ func TestProviderFromKey_RejectsUnknown(t *testing.T) {
 		t.Error("an empty key must be an error")
 	}
 }
+
+func TestAgentEnvContract_ValuesAreTheContract(t *testing.T) {
+	// A deployed runner is looking for these exact strings. Changing one makes
+	// a mismatched deploy fail SILENTLY — the marker is simply never
+	// recognised, and the task falls back rather than erroring. Renaming the Go
+	// identifiers is free; renaming these is not.
+	if EnvSubscriptionAuthMode != "CLAUDE_AUTH_MODE" {
+		t.Errorf("EnvSubscriptionAuthMode = %q; a deployed runner reads CLAUDE_AUTH_MODE", EnvSubscriptionAuthMode)
+	}
+	if SubscriptionAuthModeValue != "subscription" {
+		t.Errorf("SubscriptionAuthModeValue = %q; a deployed runner compares against \"subscription\"", SubscriptionAuthModeValue)
+	}
+	if EnvBedrockMode != "CLAUDE_CODE_USE_BEDROCK" {
+		t.Errorf("EnvBedrockMode = %q; this is also claude-code's own Bedrock switch", EnvBedrockMode)
+	}
+	if BedrockModeValue != "1" {
+		t.Errorf("BedrockModeValue = %q, want \"1\"", BedrockModeValue)
+	}
+}
+
+func TestAgentEnvContract_Helpers(t *testing.T) {
+	if !IsSubscriptionAuthMode(map[string]string{EnvSubscriptionAuthMode: SubscriptionAuthModeValue}) {
+		t.Error("subscription marker not recognised")
+	}
+	// Anything other than the exact value means not-subscription — a partial or
+	// misspelled marker must not engage subscription auth.
+	if IsSubscriptionAuthMode(map[string]string{EnvSubscriptionAuthMode: "Subscription"}) {
+		t.Error("comparison must be exact; a near-miss must not engage subscription auth")
+	}
+	if !IsBedrockMode(map[string]string{EnvBedrockMode: BedrockModeValue}) {
+		t.Error("Bedrock marker not recognised")
+	}
+	if IsBedrockMode(map[string]string{EnvBedrockMode: "true"}) {
+		t.Error("only \"1\" enables Bedrock mode")
+	}
+	if IsBedrockMode(map[string]string{}) || IsSubscriptionAuthMode(map[string]string{}) {
+		t.Error("an empty env marks nothing")
+	}
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -522,19 +522,19 @@ func TestProviderFromKey_RejectsUnknown(t *testing.T) {
 	}
 }
 
-func TestAgentEnvContract_OnlyClaudeCodesOwnSwitchRemains(t *testing.T) {
+func TestClaudeCodeUseBedrock_IsTheCLIsOwnContract(t *testing.T) {
 	// This is Anthropic's variable, not ours — a deployed claude-code is
 	// looking for this exact name and value. Ours belong in typed job
 	// parameters (parameters_enums.AgentProvider), not here.
-	if EnvBedrockMode != "CLAUDE_CODE_USE_BEDROCK" || BedrockModeValue != "1" {
-		t.Errorf("EnvBedrockMode=%q value=%q; claude-code reads CLAUDE_CODE_USE_BEDROCK=1", EnvBedrockMode, BedrockModeValue)
+	if EnvClaudeCodeUseBedrock != "CLAUDE_CODE_USE_BEDROCK" || ClaudeCodeUseBedrockValue != "1" {
+		t.Errorf("EnvClaudeCodeUseBedrock=%q value=%q; claude-code reads CLAUDE_CODE_USE_BEDROCK=1", EnvClaudeCodeUseBedrock, ClaudeCodeUseBedrockValue)
 	}
 }
 
-func TestApplyBedrockMode_OnlyForClaudeCodeOnBedrock(t *testing.T) {
+func TestApplyClaudeCodeUseBedrock_OnlyForClaudeCodeOnBedrock(t *testing.T) {
 	env := map[string]string{}
-	ApplyBedrockMode(env, AWSBedrock, ClaudeCode)
-	if env[EnvBedrockMode] != BedrockModeValue {
+	ApplyClaudeCodeUseBedrock(env, AWSBedrock, ClaudeCode)
+	if env[EnvClaudeCodeUseBedrock] != ClaudeCodeUseBedrockValue {
 		t.Error("claude-code on Bedrock needs its own switch set")
 	}
 
@@ -551,8 +551,8 @@ func TestApplyBedrockMode_OnlyForClaudeCodeOnBedrock(t *testing.T) {
 		{AnthropicSubscription, ClaudeCode},
 	} {
 		env := map[string]string{}
-		ApplyBedrockMode(env, c.p, c.a)
-		if _, ok := env[EnvBedrockMode]; ok {
+		ApplyClaudeCodeUseBedrock(env, c.p, c.a)
+		if _, ok := env[EnvClaudeCodeUseBedrock]; ok {
 			t.Errorf("%v/%v must not get claude-code's Bedrock switch", c.p, c.a)
 		}
 	}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -527,8 +527,11 @@ func TestAgentEnvContract_ValuesAreTheContract(t *testing.T) {
 	// a mismatched deploy fail SILENTLY — the marker is simply never
 	// recognised, and the task falls back rather than erroring. Renaming the Go
 	// identifiers is free; renaming these is not.
-	if EnvSubscriptionAuthMode != "CLAUDE_AUTH_MODE" {
-		t.Errorf("EnvSubscriptionAuthMode = %q; a deployed runner reads CLAUDE_AUTH_MODE", EnvSubscriptionAuthMode)
+	if EnvAgentAuthMode != "AGENT_AUTH_MODE" {
+		t.Errorf("EnvAgentAuthMode = %q, want AGENT_AUTH_MODE", EnvAgentAuthMode)
+	}
+	if EnvAgentAuthModeLegacy != "CLAUDE_AUTH_MODE" {
+		t.Errorf("EnvAgentAuthModeLegacy = %q; deployed runners still read CLAUDE_AUTH_MODE", EnvAgentAuthModeLegacy)
 	}
 	if SubscriptionAuthModeValue != "subscription" {
 		t.Errorf("SubscriptionAuthModeValue = %q; a deployed runner compares against \"subscription\"", SubscriptionAuthModeValue)
@@ -542,12 +545,18 @@ func TestAgentEnvContract_ValuesAreTheContract(t *testing.T) {
 }
 
 func TestAgentEnvContract_Helpers(t *testing.T) {
-	if !IsSubscriptionAuthMode(map[string]string{EnvSubscriptionAuthMode: SubscriptionAuthModeValue}) {
+	if !IsSubscriptionAuthMode(map[string]string{EnvAgentAuthMode: SubscriptionAuthModeValue}) {
 		t.Error("subscription marker not recognised")
+	}
+	// Both names must work during the transition. A control plane sending the
+	// new name to a runner that only knows the old one would silently fall back
+	// to the API key — metered billing, no error, tasks still passing.
+	if !IsSubscriptionAuthMode(map[string]string{EnvAgentAuthModeLegacy: SubscriptionAuthModeValue}) {
+		t.Error("the legacy name must keep working until every runner is upgraded")
 	}
 	// Anything other than the exact value means not-subscription — a partial or
 	// misspelled marker must not engage subscription auth.
-	if IsSubscriptionAuthMode(map[string]string{EnvSubscriptionAuthMode: "Subscription"}) {
+	if IsSubscriptionAuthMode(map[string]string{EnvAgentAuthMode: "Subscription"}) {
 		t.Error("comparison must be exact; a near-miss must not engage subscription auth")
 	}
 	if !IsBedrockMode(map[string]string{EnvBedrockMode: BedrockModeValue}) {
@@ -558,5 +567,33 @@ func TestAgentEnvContract_Helpers(t *testing.T) {
 	}
 	if IsBedrockMode(map[string]string{}) || IsSubscriptionAuthMode(map[string]string{}) {
 		t.Error("an empty env marks nothing")
+	}
+}
+
+// The marker is ours, not a CLI's: acting on it means removing it. A leaked
+// marker is invisible at runtime — the task still passes, the variable just
+// sits in the container — so it has to be a test.
+func TestConsumeSubscriptionAuthMode_StripsBothNames(t *testing.T) {
+	for _, name := range []string{EnvAgentAuthMode, EnvAgentAuthModeLegacy} {
+		env := map[string]string{name: SubscriptionAuthModeValue, "KEEP": "1"}
+		if !ConsumeSubscriptionAuthMode(env) {
+			t.Errorf("%s: not recognised as subscription auth", name)
+		}
+		if _, ok := env[name]; ok {
+			t.Errorf("%s leaked into the agent container env", name)
+		}
+		if env["KEEP"] != "1" {
+			t.Errorf("%s: unrelated env vars must survive", name)
+		}
+	}
+
+	// A marker set to anything else is still ours, and still must not reach the
+	// container — otherwise a typo becomes a variable the CLI can see.
+	env := map[string]string{EnvAgentAuthMode: "api-key"}
+	if ConsumeSubscriptionAuthMode(env) {
+		t.Error("a non-subscription value must not engage subscription auth")
+	}
+	if _, ok := env[EnvAgentAuthMode]; ok {
+		t.Error("the marker must be stripped even when it does not engage")
 	}
 }

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -522,78 +522,38 @@ func TestProviderFromKey_RejectsUnknown(t *testing.T) {
 	}
 }
 
-func TestAgentEnvContract_ValuesAreTheContract(t *testing.T) {
-	// A deployed runner is looking for these exact strings. Changing one makes
-	// a mismatched deploy fail SILENTLY — the marker is simply never
-	// recognised, and the task falls back rather than erroring. Renaming the Go
-	// identifiers is free; renaming these is not.
-	if EnvAgentAuthMode != "AGENT_AUTH_MODE" {
-		t.Errorf("EnvAgentAuthMode = %q, want AGENT_AUTH_MODE", EnvAgentAuthMode)
-	}
-	if EnvAgentAuthModeLegacy != "CLAUDE_AUTH_MODE" {
-		t.Errorf("EnvAgentAuthModeLegacy = %q; deployed runners still read CLAUDE_AUTH_MODE", EnvAgentAuthModeLegacy)
-	}
-	if SubscriptionAuthModeValue != "subscription" {
-		t.Errorf("SubscriptionAuthModeValue = %q; a deployed runner compares against \"subscription\"", SubscriptionAuthModeValue)
-	}
-	if EnvBedrockMode != "CLAUDE_CODE_USE_BEDROCK" {
-		t.Errorf("EnvBedrockMode = %q; this is also claude-code's own Bedrock switch", EnvBedrockMode)
-	}
-	if BedrockModeValue != "1" {
-		t.Errorf("BedrockModeValue = %q, want \"1\"", BedrockModeValue)
+func TestAgentEnvContract_OnlyClaudeCodesOwnSwitchRemains(t *testing.T) {
+	// This is Anthropic's variable, not ours — a deployed claude-code is
+	// looking for this exact name and value. Ours belong in typed job
+	// parameters (parameters_enums.AgentProvider), not here.
+	if EnvBedrockMode != "CLAUDE_CODE_USE_BEDROCK" || BedrockModeValue != "1" {
+		t.Errorf("EnvBedrockMode=%q value=%q; claude-code reads CLAUDE_CODE_USE_BEDROCK=1", EnvBedrockMode, BedrockModeValue)
 	}
 }
 
-func TestAgentEnvContract_Helpers(t *testing.T) {
-	if !IsSubscriptionAuthMode(map[string]string{EnvAgentAuthMode: SubscriptionAuthModeValue}) {
-		t.Error("subscription marker not recognised")
-	}
-	// Both names must work during the transition. A control plane sending the
-	// new name to a runner that only knows the old one would silently fall back
-	// to the API key — metered billing, no error, tasks still passing.
-	if !IsSubscriptionAuthMode(map[string]string{EnvAgentAuthModeLegacy: SubscriptionAuthModeValue}) {
-		t.Error("the legacy name must keep working until every runner is upgraded")
-	}
-	// Anything other than the exact value means not-subscription — a partial or
-	// misspelled marker must not engage subscription auth.
-	if IsSubscriptionAuthMode(map[string]string{EnvAgentAuthMode: "Subscription"}) {
-		t.Error("comparison must be exact; a near-miss must not engage subscription auth")
-	}
-	if !IsBedrockMode(map[string]string{EnvBedrockMode: BedrockModeValue}) {
-		t.Error("Bedrock marker not recognised")
-	}
-	if IsBedrockMode(map[string]string{EnvBedrockMode: "true"}) {
-		t.Error("only \"1\" enables Bedrock mode")
-	}
-	if IsBedrockMode(map[string]string{}) || IsSubscriptionAuthMode(map[string]string{}) {
-		t.Error("an empty env marks nothing")
-	}
-}
-
-// The marker is ours, not a CLI's: acting on it means removing it. A leaked
-// marker is invisible at runtime — the task still passes, the variable just
-// sits in the container — so it has to be a test.
-func TestConsumeSubscriptionAuthMode_StripsBothNames(t *testing.T) {
-	for _, name := range []string{EnvAgentAuthMode, EnvAgentAuthModeLegacy} {
-		env := map[string]string{name: SubscriptionAuthModeValue, "KEEP": "1"}
-		if !ConsumeSubscriptionAuthMode(env) {
-			t.Errorf("%s: not recognised as subscription auth", name)
-		}
-		if _, ok := env[name]; ok {
-			t.Errorf("%s leaked into the agent container env", name)
-		}
-		if env["KEEP"] != "1" {
-			t.Errorf("%s: unrelated env vars must survive", name)
-		}
+func TestApplyBedrockMode_OnlyForClaudeCodeOnBedrock(t *testing.T) {
+	env := map[string]string{}
+	ApplyBedrockMode(env, AWSBedrock, ClaudeCode)
+	if env[EnvBedrockMode] != BedrockModeValue {
+		t.Error("claude-code on Bedrock needs its own switch set")
 	}
 
-	// A marker set to anything else is still ours, and still must not reach the
-	// container — otherwise a typo becomes a variable the CLI can see.
-	env := map[string]string{EnvAgentAuthMode: "api-key"}
-	if ConsumeSubscriptionAuthMode(env) {
-		t.Error("a non-subscription value must not engage subscription auth")
-	}
-	if _, ok := env[EnvAgentAuthMode]; ok {
-		t.Error("the marker must be stripped even when it does not engage")
+	// No other agent understands this variable. codex ignores it; opencode
+	// selects Bedrock through its model id instead. Write-if-needed means these
+	// simply never get it — there is no strip step that could miss one.
+	for _, c := range []struct {
+		p Provider
+		a AgentType
+	}{
+		{AWSBedrock, Codex},
+		{AWSBedrock, Opencode},
+		{AnthropicDirect, ClaudeCode},
+		{AnthropicSubscription, ClaudeCode},
+	} {
+		env := map[string]string{}
+		ApplyBedrockMode(env, c.p, c.a)
+		if _, ok := env[EnvBedrockMode]; ok {
+			t.Errorf("%v/%v must not get claude-code's Bedrock switch", c.p, c.a)
+		}
 	}
 }

--- a/enums/parameters_enums/keys.go
+++ b/enums/parameters_enums/keys.go
@@ -130,6 +130,7 @@ const (
 	AdditionalAllowedHosts       Key = 116 //string - comma-separated extra hostnames the agentbox proxy will allow (org-level + future per-Task additions; runner unions sources before passing to container)
 	ClaudeCodeVersion            Key = 117 //string - pinned @anthropic-ai/claude-code version installed inside agentbox (e.g., "2.1.141"); empty = use the agentbox image's Dockerfile-baked default
 	CodexVersion                 Key = 118 //string - pinned @openai/codex version installed inside agentbox (e.g., "0.136.0"); empty = use the agentbox image's Dockerfile-baked default
+	AgentProvider                Key = 120 //string - llm_provider_enums.Provider slug ("anthropic-direct", "aws-bedrock", "anthropic-subscription", ...) telling the runner HOW to authenticate. Typed sibling of AgentType, deliberately NOT a marker inside AgentEnvVars: this is a control decision the runner acts on, not payload for the container.
 	SessionUUID                  Key = 119 //string - stable Assistant-session UUID forwarded to agentbox as SESSION_ID (the agent's --session-id) for conversation continuity / crash recovery across re-runs
 )
 
@@ -252,6 +253,7 @@ var keyToString = map[Key]string{
 	AdditionalAllowedHosts:       "additional allowed hosts",
 	ClaudeCodeVersion:            "claude code version",
 	CodexVersion:                 "codex version",
+	AgentProvider:                "agent provider",
 	SessionUUID:                  "session uuid",
 }
 
@@ -382,6 +384,7 @@ var keyMap = map[Key]string{
 	AdditionalAllowedHosts:       "116",
 	ClaudeCodeVersion:            "117",
 	CodexVersion:                 "118",
+	AgentProvider:                "120",
 	SessionUUID:                  "119",
 }
 

--- a/enums/parameters_enums/keys.go
+++ b/enums/parameters_enums/keys.go
@@ -130,8 +130,8 @@ const (
 	AdditionalAllowedHosts       Key = 116 //string - comma-separated extra hostnames the agentbox proxy will allow (org-level + future per-Task additions; runner unions sources before passing to container)
 	ClaudeCodeVersion            Key = 117 //string - pinned @anthropic-ai/claude-code version installed inside agentbox (e.g., "2.1.141"); empty = use the agentbox image's Dockerfile-baked default
 	CodexVersion                 Key = 118 //string - pinned @openai/codex version installed inside agentbox (e.g., "0.136.0"); empty = use the agentbox image's Dockerfile-baked default
-	AgentProvider                Key = 120 //string - llm_provider_enums.Provider slug ("anthropic-direct", "aws-bedrock", "anthropic-subscription", ...) telling the runner HOW to authenticate. Typed sibling of AgentType, deliberately NOT a marker inside AgentEnvVars: this is a control decision the runner acts on, not payload for the container.
 	SessionUUID                  Key = 119 //string - stable Assistant-session UUID forwarded to agentbox as SESSION_ID (the agent's --session-id) for conversation continuity / crash recovery across re-runs
+	AgentProvider                Key = 120 //string - llm_provider_enums.Provider slug ("anthropic-direct", "aws-bedrock", "anthropic-subscription", ...) telling the runner HOW to authenticate. Typed sibling of AgentType, deliberately NOT a marker inside AgentEnvVars: this is a control decision the runner acts on, not payload for the container.
 )
 
 var keyToString = map[Key]string{
@@ -253,8 +253,8 @@ var keyToString = map[Key]string{
 	AdditionalAllowedHosts:       "additional allowed hosts",
 	ClaudeCodeVersion:            "claude code version",
 	CodexVersion:                 "codex version",
-	AgentProvider:                "agent provider",
 	SessionUUID:                  "session uuid",
+	AgentProvider:                "agent provider",
 }
 
 func (k Key) String() string {
@@ -384,8 +384,8 @@ var keyMap = map[Key]string{
 	AdditionalAllowedHosts:       "116",
 	ClaudeCodeVersion:            "117",
 	CodexVersion:                 "118",
-	AgentProvider:                "120",
 	SessionUUID:                  "119",
+	AgentProvider:                "120",
 }
 
 func (k Key) Key() (string, error) {


### PR DESCRIPTION
### The asymmetry

`AgentType` is a typed job parameter (Key 115). The runner reads the param and *writes* `AGENT_TYPE` into the container env at [`run_agent_step.go:376`](https://github.com/deployment-io/deployment-runner/blob/master/jobs/commands/run_agent_step.go#L376).

Provider is the same kind of decision — how we run the agent — and got none of that treatment. deployment-server encoded it as a `CLAUDE_AUTH_MODE` string, stuffed it into `AgentEnvVars` next to the API key, and the runner read it back out and `delete`d it.

That round trip:
- **threw away the type** — a typed enum became a string comparison;
- **put a non-secret in the secrets channel** — `AgentEnvVars` is the decrypted-credentials bundle;
- **made breakage silent** — a name mismatch meant subscription auth never engaged and every task fell back to metered API-key billing. No error, no failing task, just a bigger invoice. The old runner comment said as much: *"change them in both or subscription auth silently stops engaging."*

### The change

`AgentProvider` (Key 120) carries the Provider slug alongside `AgentType`. The runner derives everything from it:

| decision | before | after |
|---|---|---|
| subscription auth | `env["CLAUDE_AUTH_MODE"] == "subscription"` | `provider.AuthMode() == AuthModeSubscription` |
| assume `dr-bedrock-role` | `env["CLAUDE_CODE_USE_BEDROCK"] == "1"` | `provider == AWSBedrock` |

The marker doesn't get a better name — it stops existing. No `AGENT_AUTH_MODE`, no legacy alias, no dual-read, no strip step.

### What legitimately stays

Only `CLAUDE_CODE_USE_BEDROCK`. That one is **claude-code's own switch** — its name and value are Anthropic's, not ours — which is exactly why it belongs in the container env. It flips from something we read to something the runner writes, via `ApplyBedrockMode(env, provider, agentType)`.

Write-if-needed, deliberately, rather than the strip-if-wrong-agent it replaces: removing a variable that shouldn't be there fails open (miss one path, it leaks), adding one only where it belongs cannot leak.

### Follow-ups

- **deployment-server**: set `AgentProvider` at pickup; `LLMConfig` stops emitting the marker
- **deployment-runner** (#92): read the param, drop the local `claudeAuthModeEnvVar` copies