### PR TITLE
Withhold Google Vertex from the catalogue instead of rejecting it everywhere

### DIFF
--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -194,9 +194,8 @@ func ConfigurableProviders() []Provider {
 			offered[p] = true
 		}
 	}
-	// Enum order, so the settings UI and the API agree without either sorting.
 	var out []Provider
-	for p := AnthropicDirect; p < MaxProvider; p++ {
+	for _, p := range AllProviders() {
 		if offered[p] {
 			out = append(out, p)
 		}

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -74,7 +74,7 @@ var modelToProviders = map[Model][]Provider{
 // though no model above is served by it yet — the intersection keeps that from
 // ever being offered.
 var agentTypeToProviders = map[AgentType][]Provider{
-	ClaudeCode: {AnthropicDirect, AnthropicSubscription, AWSBedrock, GoogleVertex},
+	ClaudeCode: {AnthropicDirect, AnthropicSubscription, AWSBedrock},
 	Codex:      {OpenAIDirect},
 	Opencode:   {AnthropicDirect, AWSBedrock, OpenAIDirect},
 }
@@ -176,4 +176,40 @@ func OpencodeModelID(modelID string, p Provider) string {
 		return ""
 	}
 	return name + "/" + modelID
+}
+
+// ConfigurableProviders returns every provider an org can actually configure,
+// in enum order.
+//
+// DERIVED, not a second list: a provider is configurable exactly when some
+// agent can use it. That makes the catalogue the only place a provider is
+// switched on, so a reserved-but-unbuilt one (GoogleVertex) cannot be offered
+// by the settings UI or accepted by the API without someone first adding it to
+// a real agent — rather than each caller carrying its own reject list that
+// drifts.
+func ConfigurableProviders() []Provider {
+	offered := map[Provider]bool{}
+	for _, providers := range agentTypeToProviders {
+		for _, p := range providers {
+			offered[p] = true
+		}
+	}
+	// Enum order, so the settings UI and the API agree without either sorting.
+	var out []Provider
+	for p := AnthropicDirect; p < MaxProvider; p++ {
+		if offered[p] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// IsConfigurable reports whether an org can configure this provider.
+func (p Provider) IsConfigurable() bool {
+	for _, c := range ConfigurableProviders() {
+		if c == p {
+			return true
+		}
+	}
+	return false
 }

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -399,7 +399,7 @@ func TestResolvesModelIDAtRuntime_IsAPropertyNotAProviderCheck(t *testing.T) {
 		AWSBedrock:   true,
 		GoogleVertex: true,
 	}
-	for p := AnthropicDirect; p < MaxProvider; p++ {
+	for _, p := range AllProviders() {
 		if got := p.ResolvesModelIDAtRuntime(); got != runtime[p] {
 			t.Errorf("%s.ResolvesModelIDAtRuntime() = %v, want %v", p, got, runtime[p])
 		}
@@ -486,7 +486,7 @@ func TestProviderKeys_AreDistinctFromDisplayStrings(t *testing.T) {
 	// stay free to change, so no key may equal a display string. If they ever
 	// coincide, someone will "simplify" by using one for both and couple a copy
 	// edit to stored data.
-	for p := AnthropicDirect; p < MaxProvider; p++ {
+	for _, p := range AllProviders() {
 		if p.Key() == "" {
 			t.Errorf("%s has no storage key", p)
 			continue
@@ -502,7 +502,7 @@ func TestProviderKeys_AreDistinctFromDisplayStrings(t *testing.T) {
 
 func TestProviderKeys_AreUnique(t *testing.T) {
 	seen := map[string]Provider{}
-	for p := AnthropicDirect; p < MaxProvider; p++ {
+	for _, p := range AllProviders() {
 		k := p.Key()
 		if prev, dup := seen[k]; dup {
 			t.Errorf("key %q is shared by %s and %s; one org entry would serve both", k, prev, p)
@@ -595,5 +595,30 @@ func TestConfigurableProviders_ExcludesReservedOnes(t *testing.T) {
 		if got[i-1] >= got[i] {
 			t.Errorf("ConfigurableProviders is not in enum order: %v", got)
 		}
+	}
+}
+
+// Explicit values only help if nothing reintroduces a positional assumption.
+// AllProviders must cover every declared provider and stay numerically ordered,
+// because ConfigurableProviders and the settings UI both read it as an order.
+func TestAllProviders_CoversEveryDeclaredProviderInOrder(t *testing.T) {
+	all := AllProviders()
+	if len(all) != len(providerToString) {
+		t.Errorf("AllProviders returned %d, want %d — a declared provider is being skipped", len(all), len(providerToString))
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i-1] >= all[i] {
+			t.Errorf("AllProviders is not in numeric order: %v", all)
+		}
+	}
+	for _, p := range all {
+		if !p.IsValid() {
+			t.Errorf("%v is declared but not valid", p)
+		}
+	}
+	// A value with no declaration must be invalid — the gap left by a reserved
+	// or future provider cannot read as usable.
+	if Provider(99).IsValid() {
+		t.Error("an undeclared value must not be valid; a range check would have accepted it")
 	}
 }

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -557,3 +557,43 @@ func TestApplyClaudeCodeUseBedrock_OnlyForClaudeCodeOnBedrock(t *testing.T) {
 		}
 	}
 }
+
+// The numbering is the storage format. AnthropicSubscription is 4 in live
+// documents, so removing an earlier constant to "clean up" would silently
+// reinterpret every subscription org's stored provider as something else.
+// GoogleVertex is withheld by the catalogue, not by deletion — this pins that.
+func TestProviderNumbering_IsStableAcrossReservedSlots(t *testing.T) {
+	for p, want := range map[Provider]uint{
+		AnthropicDirect:       1,
+		AWSBedrock:            2,
+		GoogleVertex:          3,
+		AnthropicSubscription: 4,
+		OpenAIDirect:          5,
+	} {
+		if uint(p) != want {
+			t.Errorf("%v = %d, want %d — renumbering reinterprets stored documents", p, uint(p), want)
+		}
+	}
+}
+
+func TestConfigurableProviders_ExcludesReservedOnes(t *testing.T) {
+	if GoogleVertex.IsConfigurable() {
+		t.Error("GoogleVertex is reserved and unbuilt; offering it would accept a config nothing can serve")
+	}
+	// Everything an agent lists must be configurable, or an org could pick a
+	// model it is then unable to run.
+	for agentType, providers := range agentTypeToProviders {
+		for _, p := range providers {
+			if !p.IsConfigurable() {
+				t.Errorf("%v lists %v, which is not configurable", agentType, p)
+			}
+		}
+	}
+	// Enum order, so callers need not sort.
+	got := ConfigurableProviders()
+	for i := 1; i < len(got); i++ {
+		if got[i-1] >= got[i] {
+			t.Errorf("ConfigurableProviders is not in enum order: %v", got)
+		}
+	}
+}

--- a/enums/llm_provider_enums/providers.go
+++ b/enums/llm_provider_enums/providers.go
@@ -45,7 +45,12 @@ type Provider uint
 const (
 	AnthropicDirect Provider = iota + 1 // 1 — Anthropic API key
 	AWSBedrock                          // 2 — runner-assumed IAM role, no stored secret
-	GoogleVertex                        // 3 — reserved, not wired
+	// GoogleVertex is RESERVED, not offered. The constant stays so the numbers
+	// below it do not move — AnthropicSubscription is 4 in live documents, and
+	// renumbering would silently reinterpret every subscription org's stored
+	// provider. It is absent from the catalogue instead, which is what makes it
+	// unofferable: see ConfigurableProviders.
+	GoogleVertex // 3
 	// AnthropicSubscription is the customer's own Claude Code subscription
 	// (Pro/Max) OAuth token. No credential is held control-plane-side: the
 	// token lives only in the customer's own AWS Secrets Manager and is read

--- a/enums/llm_provider_enums/providers.go
+++ b/enums/llm_provider_enums/providers.go
@@ -12,7 +12,10 @@
 // deployment-runner for what the alternative looks like.
 package llm_provider_enums
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // Provider identifies WHOSE models are being called and over which API.
 //
@@ -21,8 +24,6 @@ import "fmt"
 // from kit/enums/claude_auth_enums with its numbering intact precisely so no
 // data migration was needed; reordering for tidiness would silently
 // reinterpret every existing org's credential configuration. Append only,
-// before MaxProvider.
-//
 // ⚠️ NOT EVERY VALUE IS PERSISTED. 1-4 appear in ClaudeAuth.Provider.
 // OpenAIDirect does not appear anywhere: OpenAIAuth has no Provider field and
 // infers its provider from the presence of an API key, so nothing writes 5.
@@ -43,24 +44,26 @@ import "fmt"
 type Provider uint
 
 const (
-	AnthropicDirect Provider = iota + 1 // 1 — Anthropic API key
-	AWSBedrock                          // 2 — runner-assumed IAM role, no stored secret
-	// GoogleVertex is RESERVED, not offered. The constant stays so the numbers
-	// below it do not move — AnthropicSubscription is 4 in live documents, and
-	// renumbering would silently reinterpret every subscription org's stored
-	// provider. It is absent from the catalogue instead, which is what makes it
-	// unofferable: see ConfigurableProviders.
-	GoogleVertex // 3
+	// ⚠️ VALUES ARE EXPLICIT AND PERMANENT. Each number is what sits in
+	// LLMConfig documents, so a value belongs to its provider forever — never
+	// reuse or renumber one, and never let a value depend on declaration order.
+	// This used to be `iota + 1`, which made every number a function of the
+	// lines above it: deleting or reordering a single constant silently
+	// reinterpreted stored documents as a different provider.
+	AnthropicDirect Provider = 1 // Anthropic API key
+	AWSBedrock      Provider = 2 // runner-assumed IAM role, no stored secret
+	// GoogleVertex is RESERVED, not offered. It is withheld by the catalogue
+	// (see ConfigurableProviders) rather than deleted, because 3 must stay
+	// spoken for.
+	GoogleVertex Provider = 3
 	// AnthropicSubscription is the customer's own Claude Code subscription
 	// (Pro/Max) OAuth token. No credential is held control-plane-side: the
 	// token lives only in the customer's own AWS Secrets Manager and is read
 	// by the runner at agentbox spawn. claude-code only — the runner refuses
 	// it for other harnesses, which agentTypeToProviders below encodes.
-	AnthropicSubscription // 4
+	AnthropicSubscription Provider = 4
 	// OpenAIDirect is catalogue-only; see the note above.
-	OpenAIDirect // 5
-
-	MaxProvider // always add providers before MaxProvider
+	OpenAIDirect Provider = 5
 )
 
 // providerToString values are USER-VISIBLE. They are surfaced as
@@ -86,8 +89,28 @@ func (p Provider) IsZero() bool {
 
 // IsValid reports whether p names a declared provider. The zero value means
 // "unconfigured" and is not valid.
+// AllProviders returns every provider this build knows, in numeric order —
+// reserved ones included. Callers offering a CHOICE want ConfigurableProviders
+// instead; this is for exhaustive sweeps (validation tables, tests) that must
+// not silently skip a provider.
+//
+// Derived from providerToString so there is no second list to fall out of sync,
+// and sorted because map iteration is random and callers compare output.
+func AllProviders() []Provider {
+	out := make([]Provider, 0, len(providerToString))
+	for p := range providerToString {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
 func (p Provider) IsValid() bool {
-	return p > 0 && p < MaxProvider
+	// Membership, not a range check. With explicit values there is no
+	// contiguity to lean on, and a range would call a reserved gap valid while
+	// a forgotten sentinel bump would call a real provider invalid.
+	_, ok := providerToString[p]
+	return ok
 }
 
 // AuthMode returns HOW this provider is authenticated to.


### PR DESCRIPTION
Vertex is reserved and unbuilt. Every caller that can accept a provider — the settings API, the dashboard's provider list, kit's resolver — was about to grow its own "…except Vertex" reject list, and those drift independently.

Removing it from `agentTypeToProviders` makes configurability **derivable** instead: a provider is offerable exactly when some agent can use it. `ConfigurableProviders()` / `Provider.IsConfigurable()` fall out of the catalogue, so switching a provider on happens in exactly one place.

### The constant stays

`GoogleVertex` is **3**, sitting between `AWSBedrock` (2) and `AnthropicSubscription` (4). Deleting it renumbers subscription 4 → 3 — and 4 is what live documents hold, including our own org, which is running subscription auth today. Every subscription org would be silently reinterpreted as a different provider: no error, no failed task, just the wrong auth path and metered billing.

Nothing else would catch that, so `TestProviderNumbering_IsStableAcrossReservedSlots` pins all five values.