### PR TITLE
Make the Bedrock-mode rule one predicate, not two copies

### DIFF
--- a/enums/llm_provider_enums/agent_env.go
+++ b/enums/llm_provider_enums/agent_env.go
@@ -34,6 +34,15 @@ const (
 	// reads it back. Derive from Provider instead.
 	EnvClaudeCodeUseBedrock = "CLAUDE_CODE_USE_BEDROCK"
 
+	// EnvModel is agentbox's generic model variable, read by whichever agent it
+	// spawns.
+	EnvModel = "MODEL"
+
+	// EnvClaudeCodeBedrockModel is where claude-code reads its model when — and
+	// only when — it is in Bedrock mode. Off Bedrock it takes the model from
+	// EnvModel instead. Anthropic's variable, like the switch above.
+	EnvClaudeCodeBedrockModel = "ANTHROPIC_MODEL"
+
 	// ClaudeCodeUseBedrockValue is what EnvClaudeCodeUseBedrock is set to.
 	// Meaningless on its own — it exists only to name that variable's value,
 	// which is what binds it to claude-code too.
@@ -52,7 +61,37 @@ const (
 // fails open — miss one path and it leaks into the container. Pushing the
 // agent check back to the caller would reintroduce exactly that.
 func ApplyClaudeCodeUseBedrock(env map[string]string, p Provider, agentType AgentType) {
-	if p == AWSBedrock && agentType == ClaudeCode {
+	if ClaudeCodeUsesBedrock(p, agentType) {
 		env[EnvClaudeCodeUseBedrock] = ClaudeCodeUseBedrockValue
 	}
+}
+
+// ClaudeCodeUsesBedrock reports whether this spawn puts claude-code into its
+// Bedrock mode.
+//
+// ONE predicate, because putting claude-code in Bedrock mode and telling it
+// where to read the model are two halves of the same fact. They were written
+// out separately — the switch here, the model variable in deployment-runner —
+// and had already drifted: the runner keyed the model variable on the provider
+// alone, so codex on Bedrock would have been pointed at a variable only
+// claude-code reads. An agent in Bedrock mode reading the wrong variable, or
+// reading the right one without being in the mode, is broken either way.
+//
+// Deliberately not phrased as "is this Bedrock": the answer depends on the
+// AGENT. opencode reaches Bedrock too, through its own "amazon-bedrock/…" model
+// id, and must not be caught by this.
+func ClaudeCodeUsesBedrock(p Provider, agentType AgentType) bool {
+	return p == AWSBedrock && agentType == ClaudeCode
+}
+
+// ModelEnvVar returns the env var this spawn's agent reads its model from.
+//
+// Exists so no caller writes that branch itself. It is the same fact as
+// ApplyClaudeCodeUseBedrock, and the two cannot disagree because both derive
+// from ClaudeCodeUsesBedrock.
+func ModelEnvVar(p Provider, agentType AgentType) string {
+	if ClaudeCodeUsesBedrock(p, agentType) {
+		return EnvClaudeCodeBedrockModel
+	}
+	return EnvModel
 }

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -622,3 +622,29 @@ func TestAllProviders_CoversEveryDeclaredProviderInOrder(t *testing.T) {
 		t.Error("an undeclared value must not be valid; a range check would have accepted it")
 	}
 }
+
+// The invariant this pair exists to hold: an agent is put into Bedrock mode by
+// exactly the same rule that decides where it reads its model. Split across two
+// repos it could not be tested at all, and it had already drifted.
+func TestModelEnvVar_AgreesWithTheBedrockSwitch(t *testing.T) {
+	for _, p := range AllProviders() {
+		for _, agentType := range []AgentType{ClaudeCode, Codex, Opencode} {
+			env := map[string]string{}
+			ApplyClaudeCodeUseBedrock(env, p, agentType)
+			inBedrockMode := env[EnvClaudeCodeUseBedrock] == ClaudeCodeUseBedrockValue
+			readsAnthropicModel := ModelEnvVar(p, agentType) == EnvClaudeCodeBedrockModel
+			if inBedrockMode != readsAnthropicModel {
+				t.Errorf("%v/%v: Bedrock mode = %v but reads %s — an agent in the mode must read ANTHROPIC_MODEL, and one reading it must be in the mode",
+					p, agentType, inBedrockMode, ModelEnvVar(p, agentType))
+			}
+		}
+	}
+	// The concrete case that was wrong: codex on Bedrock reads the generic var.
+	if got := ModelEnvVar(AWSBedrock, Codex); got != EnvModel {
+		t.Errorf("codex on Bedrock reads %s; only claude-code reads ANTHROPIC_MODEL", got)
+	}
+	// And opencode, which reaches Bedrock through its model id, not a switch.
+	if got := ModelEnvVar(AWSBedrock, Opencode); got != EnvModel {
+		t.Errorf("opencode on Bedrock reads %s, want %s", got, EnvModel)
+	}
+}


### PR DESCRIPTION
Putting claude-code into Bedrock mode and telling it *where to read its model* are two halves of one fact. They were written out separately in two repos — the `CLAUDE_CODE_USE_BEDROCK` switch here, the `ANTHROPIC_MODEL` branch in deployment-runner — and they had already drifted:

```go
// deployment-runner, before this
if provider == llm_provider_enums.AWSBedrock {   // provider alone
    env["ANTHROPIC_MODEL"] = id
```

So **codex on Bedrock would have been told to read a variable only claude-code consults**. Unreachable today; silent the moment it isn't.

### The fix

`ClaudeCodeUsesBedrock(p, agentType)` is the single rule. `ApplyClaudeCodeUseBedrock` and the new `ModelEnvVar` both derive from it, so they cannot disagree — the runner writes `env[ModelEnvVar(provider, agentType)] = id` and no longer carries the branch at all.

It is deliberately **not** phrased as "is this Bedrock". The answer depends on the agent: opencode reaches Bedrock too, via its own `amazon-bedrock/…` model id, and must not be caught by it.

### The test that couldn't exist before

While the two halves lived in different repos, nothing could check they agreed. `TestModelEnvVar_AgreesWithTheBedrockSwitch` sweeps every provider × agent pair and asserts equivalence in both directions: an agent in Bedrock mode must read `ANTHROPIC_MODEL`, and one reading it must be in the mode.

Follow-up: deployment-runner #92 drops its local branch in favour of `ModelEnvVar`.