### PR TITLE
Serve model display names, defaults and the offerable set from the catalogue

### DIFF
--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -270,3 +270,56 @@ func preferenceRank(p Provider) int {
 	}
 	return 1
 }
+
+// agentTypeToDefaultModel is the model a picker should preselect.
+//
+// A product choice, so it lives beside the catalogue rather than in whichever
+// client renders the picker first — two clients would otherwise preselect
+// differently for the same agent.
+var agentTypeToDefaultModel = map[AgentType]Model{
+	// Anthropic's documented pick for agentic coding.
+	ClaudeCode: ClaudeOpus48,
+	// OpenAI's recommended default for Codex.
+	Codex: Gpt55,
+	// Balanced, and reuses an org's existing Anthropic credential — so opencode
+	// is usable without configuring a new provider.
+	Opencode: ClaudeSonnet46,
+}
+
+// DefaultModel returns the model to preselect for this agent.
+func (h AgentType) DefaultModel() Model { return agentTypeToDefaultModel[h] }
+
+// ModelsFor returns the models this agent can run that the org can actually
+// serve, in catalogue order.
+//
+// The intersection callers keep needing: a model is offerable only when the
+// agent runs it AND some provider serving it is configured. Offering more than
+// that means a picker shows a model whose Task fails at pickup — which is what
+// a client-side model list cannot avoid, because it cannot see the org.
+//
+// isConfigured is passed in rather than the org itself: this package must not
+// learn what an organization is.
+func ModelsFor(h AgentType, isConfigured func(Provider) bool) []Model {
+	var out []Model
+	for _, m := range agentTypeToModels[h] {
+		for _, p := range ProvidersFor(h, m) {
+			if isConfigured(p) {
+				out = append(out, m)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// AllAgentTypes returns every agent, in priority order — the same order
+// AgentTypesFor uses to break a tie when several can run one model.
+func AllAgentTypes() []AgentType {
+	var out []AgentType
+	for h := ClaudeCode; h < MaxAgentType; h++ {
+		if h.IsValid() {
+			out = append(out, h)
+		}
+	}
+	return out
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -692,3 +692,65 @@ func TestPreferredProvider_PrefersWhatTheOrgAlreadyPaysFor(t *testing.T) {
 		t.Error("nothing configured must report no provider, not a guess")
 	}
 }
+
+// A model with no display name renders as its wire id — legible but wrong for a
+// picker, and the kind of gap nobody notices until a customer sees it.
+func TestModel_EveryCatalogueModelHasADisplayName(t *testing.T) {
+	for _, models := range agentTypeToModels {
+		for _, m := range models {
+			if _, named := modelToDisplayName[m]; !named {
+				t.Errorf("%v has no display name; a picker would show its wire id", m)
+			}
+			// The label must NOT be the wire id: they have different jobs, and
+			// letting them coincide invites someone to use one for the other.
+			if m.DisplayName() == m.String() {
+				t.Errorf("%v: display name equals the wire id %q", m, m.String())
+			}
+		}
+	}
+}
+
+// A default no picker can offer is worse than none: the UI preselects something
+// the org cannot run, and the first Task fails.
+func TestAgentType_DefaultModelIsOneItRuns(t *testing.T) {
+	for _, h := range AllAgentTypes() {
+		def := h.DefaultModel()
+		if def == 0 {
+			t.Errorf("%v has no default model", h)
+			continue
+		}
+		if !h.Supports(def) {
+			t.Errorf("%v defaults to %v, which it cannot run", h, def)
+		}
+	}
+}
+
+func TestModelsFor_OffersOnlyWhatTheOrgCanServe(t *testing.T) {
+	bedrockOnly := func(p Provider) bool { return p == AWSBedrock }
+	got := ModelsFor(Opencode, bedrockOnly)
+	names := map[Model]bool{}
+	for _, m := range got {
+		names[m] = true
+	}
+	// Nova is Bedrock-only, so a Bedrock org must see it.
+	if !names[NovaProV1] {
+		t.Errorf("opencode/Bedrock omits nova-pro-v1; got %v", got)
+	}
+	// Claude models are served by Bedrock too.
+	if !names[ClaudeSonnet46] {
+		t.Errorf("opencode/Bedrock omits claude-sonnet-4-6; got %v", got)
+	}
+	// GPT-5.5 is NOT on Bedrock — it is OpenAI's own model, so it must be
+	// withheld even though opencode can reach Bedrock perfectly well.
+	if names[Gpt55] {
+		t.Errorf("opencode/Bedrock offers gpt-5.5, which no Bedrock provider serves; got %v", got)
+	}
+	// Codex has no Bedrock transport at all, so nothing is offerable.
+	if got := ModelsFor(Codex, bedrockOnly); len(got) != 0 {
+		t.Errorf("codex on a Bedrock-only org offers %v, but it cannot reach Bedrock", got)
+	}
+	// Nothing configured offers nothing — never a fallback to "all models".
+	if got := ModelsFor(ClaudeCode, func(Provider) bool { return false }); len(got) != 0 {
+		t.Errorf("an unconfigured org was offered %v", got)
+	}
+}

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -197,3 +197,33 @@ func (m Model) IDFor(p Provider) string {
 	}
 	return m.String()
 }
+
+// modelToDisplayName is what a human calls the model, without its vendor —
+// "Sonnet 4.6", not "claude-sonnet-4-6" and not "Anthropic Sonnet 4.6".
+//
+// Separate from String(), which is the WIRE id and must never move: a copy edit
+// to a label would otherwise change what gets sent to a provider. Vendor is
+// separate too, so a caller composes "Anthropic · Sonnet 4.6" or groups by
+// vendor without this map having to pick one presentation.
+//
+// Lived in the dashboard until now, which meant a model added here was invisible
+// there until someone remembered to mirror it — and mirrored ids drifted from
+// the catalogue three times.
+var modelToDisplayName = map[Model]string{
+	ClaudeHaiku45:  "Haiku 4.5",
+	ClaudeSonnet46: "Sonnet 4.6",
+	ClaudeOpus48:   "Opus 4.8",
+	Gpt55:          "GPT-5.5",
+	Gpt53Codex:     "GPT-5.3 Codex",
+	Gpt54:          "GPT-5.4",
+	NovaProV1:      "Nova Pro",
+}
+
+// DisplayName returns the human-facing name, falling back to the wire id so an
+// unnamed model still renders as something rather than blank.
+func (m Model) DisplayName() string {
+	if name, ok := modelToDisplayName[m]; ok {
+		return name
+	}
+	return m.String()
+}


### PR DESCRIPTION
Groundwork for a models API, so the dashboard can stop keeping its own copy of the catalogue.

### Why

The dashboard's `MODELS_BY_AGENT` drifted four ways at once, all introduced by catalogue changes nobody mirrored:

| drift | consequence |
|---|---|
| opencode ids still provider-prefixed | **every** opencode Task creation rejected by app-server |
| `nova-pro-v1` absent | Bedrock smoke test not settable from the UI |
| `agentTypeForModel` checked opencode first | dashboard labelled the agent differently from the server |
| round-trip test | encoded "model→agent is a function", which logical ids invalidated |

### What this adds

- **`Model.DisplayName()`** — `"Sonnet 4.6"`. Separate from `String()` (the wire id) so a copy edit cannot change what is sent to a provider, and separate from `Vendor()` so a caller composes `"Anthropic · Sonnet 4.6"` or groups by vendor itself.
- **`AgentType.DefaultModel()`** — a product choice, so it belongs beside the catalogue rather than in whichever client renders a picker first. Two clients would otherwise preselect differently.
- **`ModelsFor(agent, isConfigured)`** — the intersection callers keep needing: offerable only when the agent runs it **and** a provider serving it is configured. This is precisely what a client-side list cannot compute, because it cannot see the org.

`isConfigured` is a predicate rather than an org, so this package never learns what an organization is.

### Worth knowing

`ModelsFor` makes the two axes visible in one call. For a **Bedrock-only** org:

```
claude-code  → haiku, sonnet, opus
opencode     → haiku, sonnet, opus, nova-pro-v1
codex        → (nothing — no Bedrock transport)
```

GPT-5.5 is withheld from opencode even though opencode reaches Bedrock fine: `gpt-5.5` is OpenAI's own model and no Bedrock provider serves it. Pinned by tests.