### PR TITLE
Add agent display name and interactive-session capability

### DIFF
--- a/enums/llm_provider_enums/agent_types.go
+++ b/enums/llm_provider_enums/agent_types.go
@@ -66,3 +66,38 @@ func ResolveAgentType(s string) (AgentType, error) {
 	}
 	return 0, fmt.Errorf("unknown agent harness %q", s)
 }
+
+// agentTypeToDisplayName is what a human calls the agent. Separate from
+// String(), which is the AGENT_TYPE wire value agentbox switches on — letting a
+// copy edit change what gets sent to a container is the class of bug this
+// package exists to end.
+var agentTypeToDisplayName = map[AgentType]string{
+	ClaudeCode: "Claude Code",
+	Codex:      "Codex",
+	Opencode:   "opencode",
+}
+
+// DisplayName returns the human-facing name, falling back to the wire value so
+// an unnamed agent still renders as something.
+func (h AgentType) DisplayName() string {
+	if name, ok := agentTypeToDisplayName[h]; ok {
+		return name
+	}
+	return h.String()
+}
+
+// batchOnlyAgentTypes cannot run an interactive Assistant session.
+//
+// A capability of the AGENT, so it belongs here rather than in whichever client
+// renders a session picker. opencode has no interactive mode in agentbox: it
+// runs a batch invocation and exits, so a session would have nothing to talk
+// to.
+var batchOnlyAgentTypes = map[AgentType]bool{
+	Opencode: true,
+}
+
+// SupportsInteractiveSession reports whether this agent can back an Assistant
+// session, as opposed to batch Task Steps only.
+func (h AgentType) SupportsInteractiveSession() bool {
+	return !batchOnlyAgentTypes[h]
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -754,3 +754,29 @@ func TestModelsFor_OffersOnlyWhatTheOrgCanServe(t *testing.T) {
 		t.Errorf("an unconfigured org was offered %v", got)
 	}
 }
+
+// An agent with no display name renders as its wire value — legible, but it
+// means AGENT_TYPE leaked into the UI.
+func TestAgentType_EveryAgentHasADisplayName(t *testing.T) {
+	for _, h := range AllAgentTypes() {
+		if _, named := agentTypeToDisplayName[h]; !named {
+			t.Errorf("%v has no display name", h)
+		}
+	}
+	// At least one agent must back interactive sessions, or the Assistant has
+	// nothing to offer.
+	interactive := 0
+	for _, h := range AllAgentTypes() {
+		if h.SupportsInteractiveSession() {
+			interactive++
+		}
+	}
+	if interactive == 0 {
+		t.Error("no agent supports interactive sessions; the Assistant picker would be empty")
+	}
+	// opencode is batch-only: agentbox runs it and it exits, so a session would
+	// have nothing to talk to.
+	if Opencode.SupportsInteractiveSession() {
+		t.Error("opencode has no interactive mode in agentbox")
+	}
+}


### PR DESCRIPTION
The dashboard hardcodes agent-level data the catalogue should own — labels, and a `BATCH_ONLY_AGENTS = ["opencode"]` list. The second is a genuine agent **capability**: agentbox runs opencode as a batch invocation and it exits, so an interactive session would have nothing to talk to. That belongs here, not in whichever client renders a session picker.

- `AgentType.DisplayName()` — "Claude Code". Separate from `String()`, which is the `AGENT_TYPE` wire value agentbox switches on; letting a copy edit change what reaches a container is the bug class this package exists to end.
- `AgentType.SupportsInteractiveSession()` — false for opencode.

Completes the set needed for the dashboard to hold no model, provider, or agent tables of its own.