### PR TITLE
Add the 4.5-generation Claude models

### DIFF
--- a/enums/llm_provider_enums/agent_types.go
+++ b/enums/llm_provider_enums/agent_types.go
@@ -25,11 +25,15 @@ import "fmt"
 type AgentType uint
 
 const (
-	ClaudeCode AgentType = iota + 1
-	Codex
-	Opencode
+	// Explicit values, like parameters_enums.Key and Provider. These are not
+	// persisted — Task.AgentType stores the STRING — but a value that depends
+	// on the lines above it is a trap either way, and the enum is swept by
+	// AllAgentTypes below rather than counted through.
+	ClaudeCode AgentType = 1
+	Codex      AgentType = 2
+	Opencode   AgentType = 3
 
-	MaxAgentType // always add harnesses before MaxAgentType
+	MaxAgentType AgentType = 4 // kept only for callers still ranging; prefer AllAgentTypes
 )
 
 var agentTypeToString = map[AgentType]string{
@@ -100,4 +104,28 @@ var batchOnlyAgentTypes = map[AgentType]bool{
 // session, as opposed to batch Task Steps only.
 func (h AgentType) SupportsInteractiveSession() bool {
 	return !batchOnlyAgentTypes[h]
+}
+
+// agentTypePriority decides which agent runs a model that SEVERAL can run.
+//
+// Explicit, because this used to be the enum's declaration order: AgentTypesFor
+// counted up from ClaudeCode, so "claude-code wins a shared model" was encoded
+// in the fact that it happened to be 1. Renumbering or inserting an agent would
+// have silently changed which harness ran an existing Task.
+//
+// Lower wins. Claude Code leads as the most established harness; opencode is
+// last because it is the provider-agnostic one and the least specific answer
+// when something else can run the model too.
+var agentTypePriority = map[AgentType]int{
+	ClaudeCode: 0,
+	Codex:      1,
+	Opencode:   2,
+}
+
+// Priority returns the tie-break rank for a model several agents can run.
+func (h AgentType) Priority() int {
+	if p, ok := agentTypePriority[h]; ok {
+		return p
+	}
+	return len(agentTypePriority) // unranked agents sort last, deterministically
 }

--- a/enums/llm_provider_enums/agent_types.go
+++ b/enums/llm_provider_enums/agent_types.go
@@ -32,8 +32,6 @@ const (
 	ClaudeCode AgentType = 1
 	Codex      AgentType = 2
 	Opencode   AgentType = 3
-
-	MaxAgentType AgentType = 4 // kept only for callers still ranging; prefer AllAgentTypes
 )
 
 var agentTypeToString = map[AgentType]string{
@@ -55,7 +53,12 @@ func (h AgentType) String() string {
 }
 
 func (h AgentType) IsValid() bool {
-	return h > 0 && h < MaxAgentType
+	// Membership, not a range. A sentinel has to be hand-bumped, so adding an
+	// agent and forgetting reads as INVALID, while reserving a value makes the
+	// gap read as valid. Neither fails loudly. Same reason Provider dropped
+	// MaxProvider.
+	_, ok := agentTypeToString[h]
+	return ok
 }
 
 // ResolveAgentType parses an AGENT_TYPE string. The empty string resolves to

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -154,11 +154,18 @@ func ProvidersFor(h AgentType, m Model) []Provider {
 // sensible default.
 func AgentTypesFor(m Model) []AgentType {
 	var out []AgentType
-	for h := ClaudeCode; h < MaxAgentType; h++ {
+	for _, h := range AllAgentTypes() {
 		if h.Supports(m) {
 			out = append(out, h)
 		}
 	}
+	// Ranked EXPLICITLY, not by enum order. Callers take [0] as the agent that
+	// will run the model, so this decides which harness a shared id resolves
+	// to — far too load-bearing to be a side effect of which constant came
+	// first.
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Priority() < out[j].Priority()
+	})
 	return out
 }
 
@@ -331,11 +338,14 @@ func ModelsFor(h AgentType, isConfigured func(Provider) bool) []Model {
 // AllAgentTypes returns every agent, in priority order — the same order
 // AgentTypesFor uses to break a tie when several can run one model.
 func AllAgentTypes() []AgentType {
-	var out []AgentType
-	for h := ClaudeCode; h < MaxAgentType; h++ {
-		if h.IsValid() {
-			out = append(out, h)
-		}
+	// Swept from the declaration map, not counted from ClaudeCode to
+	// MaxAgentType. Counting assumes the values are contiguous, which stops
+	// being true the moment one is reserved or retired — the same reason
+	// AllProviders is derived rather than ranged.
+	out := make([]AgentType, 0, len(agentTypeToString))
+	for h := range agentTypeToString {
+		out = append(out, h)
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 	return out
 }

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -159,13 +159,9 @@ func AgentTypesFor(m Model) []AgentType {
 			out = append(out, h)
 		}
 	}
-	// Ranked EXPLICITLY, not by enum order. Callers take [0] as the agent that
-	// will run the model, so this decides which harness a shared id resolves
-	// to — far too load-bearing to be a side effect of which constant came
-	// first.
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].Priority() < out[j].Priority()
-	})
+	// Already in priority order — AllAgentTypes ranks, and this only filters.
+	// Callers take [0] as the agent that will run the model, so that ranking
+	// decides which harness a shared id resolves to.
 	return out
 }
 
@@ -346,6 +342,16 @@ func AllAgentTypes() []AgentType {
 	for h := range agentTypeToString {
 		out = append(out, h)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	// PRIORITY order, not numeric. This is what app-server iterates to build
+	// the agent picker, so sorting by value would put the enum's declaration
+	// order on screen — the same dependency AgentTypesFor just stopped
+	// carrying. Value is the tie-break only, so the result stays deterministic
+	// if two agents ever share a rank.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Priority() != out[j].Priority() {
+			return out[i].Priority() < out[j].Priority()
+		}
+		return out[i] < out[j]
+	})
 	return out
 }

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -1,5 +1,7 @@
 package llm_provider_enums
 
+import "sort"
+
 // The catalogue: which (harness, model, provider) combinations are real.
 //
 // Held as THREE FLAT TABLES rather than one nested map[AgentType]map[Model][]Provider,
@@ -313,6 +315,16 @@ func ModelsFor(h AgentType, isConfigured func(Provider) bool) []Model {
 			}
 		}
 	}
+	// Legacy generations last, current order preserved within each group. Done
+	// HERE rather than in agentTypeToModels because that list is
+	// capability-ascending and kit's recommendedByComplexity indexes into it —
+	// reordering it would make "high complexity" resolve to a superseded model.
+	//
+	// Sorted server-side so every client agrees. A picker that ordered these
+	// itself would be one more copy of a catalogue fact.
+	sort.SliceStable(out, func(i, j int) bool {
+		return !out[i].IsLegacy() && out[j].IsLegacy()
+	})
 	return out
 }
 

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -334,10 +334,10 @@ func ModelsFor(h AgentType, isConfigured func(Provider) bool) []Model {
 // AllAgentTypes returns every agent, in priority order — the same order
 // AgentTypesFor uses to break a tie when several can run one model.
 func AllAgentTypes() []AgentType {
-	// Swept from the declaration map, not counted from ClaudeCode to
-	// MaxAgentType. Counting assumes the values are contiguous, which stops
-	// being true the moment one is reserved or retired — the same reason
-	// AllProviders is derived rather than ranged.
+	// Swept from the declaration map rather than counted through a range.
+	// Counting assumes the values are contiguous, which stops being true the
+	// moment one is reserved or retired — the same reason AllProviders is
+	// derived.
 	out := make([]AgentType, 0, len(agentTypeToString))
 	for h := range agentTypeToString {
 		out = append(out, h)

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -34,9 +34,9 @@ package llm_provider_enums
 // and §4.1, where the prefix's second job (disambiguating the harness) is what
 // made stripping it dangerous until AgentType became explicit.
 var agentTypeToModels = map[AgentType][]Model{
-	ClaudeCode: {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48},
+	ClaudeCode: {ClaudeHaiku45, ClaudeSonnet45, ClaudeSonnet46, ClaudeOpus45, ClaudeOpus48},
 	Codex:      {Gpt55, Gpt53Codex, Gpt54},
-	Opencode:   {ClaudeHaiku45, ClaudeSonnet46, ClaudeOpus48, Gpt55, NovaProV1},
+	Opencode:   {ClaudeHaiku45, ClaudeSonnet45, ClaudeSonnet46, ClaudeOpus45, ClaudeOpus48, Gpt55, NovaProV1},
 }
 
 // modelToProviders lists which providers can serve each model.
@@ -57,6 +57,10 @@ var modelToProviders = map[Model][]Provider{
 	// its vendor. claude-code and codex cannot run it — agentTypeToModels keeps
 	// it to opencode.
 	NovaProV1: {AWSBedrock},
+	// Same providers as their 4.6/4.8 siblings — the direct API and a
+	// subscription still serve them, and Bedrock is where they matter most.
+	ClaudeSonnet45: {AnthropicDirect, AnthropicSubscription, AWSBedrock},
+	ClaudeOpus45:   {AnthropicDirect, AnthropicSubscription, AWSBedrock},
 }
 
 // agentProviderCapabilities lists which provider APIs each CLI can talk to.

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -812,3 +812,49 @@ func TestCatalog_GenerationsCoexistWithoutShadowing(t *testing.T) {
 		}
 	}
 }
+
+// Legacy models sort last in pickers, but must NOT be reordered in
+// agentTypeToModels — kit's recommendedByComplexity indexes into that list, so
+// putting a superseded model at the end would make "high complexity" pick it.
+func TestModelsFor_LegacySortsLastWithoutDisturbingCapabilityOrder(t *testing.T) {
+	all := func(Provider) bool { return true }
+	got := ModelsFor(ClaudeCode, all)
+
+	seenLegacy := false
+	for _, m := range got {
+		if m.IsLegacy() {
+			seenLegacy = true
+			continue
+		}
+		if seenLegacy {
+			t.Errorf("current model %v appears after a legacy one in %v", m, got)
+		}
+	}
+	// Order WITHIN each group is preserved, so the picker still reads
+	// low->high inside the current models.
+	var current []Model
+	for _, m := range got {
+		if !m.IsLegacy() {
+			current = append(current, m)
+		}
+	}
+	var expected []Model
+	for _, m := range agentTypeToModels[ClaudeCode] {
+		if !m.IsLegacy() {
+			expected = append(expected, m)
+		}
+	}
+	for i := range expected {
+		if current[i] != expected[i] {
+			t.Errorf("current models reordered: got %v, want %v", current, expected)
+			break
+		}
+	}
+
+	// The capability list itself must stay ascending — the last entry is what
+	// a high-complexity session gets, and it must not be superseded.
+	lineup := agentTypeToModels[ClaudeCode]
+	if lineup[len(lineup)-1].IsLegacy() {
+		t.Errorf("agentTypeToModels[ClaudeCode] ends with legacy %v; high complexity would pick it", lineup[len(lineup)-1])
+	}
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -105,6 +105,15 @@ func TestModel_WireStringsAreStable(t *testing.T) {
 		Gpt53Codex:     "gpt-5.3-codex",
 		Gpt54:          "gpt-5.4",
 		NovaProV1:      "nova-pro-v1",
+		ClaudeSonnet45: "claude-sonnet-4-5",
+		ClaudeOpus45:   "claude-opus-4-5",
+	}
+	// EXHAUSTIVE. Without this, adding a model leaves its wire id unpinned and
+	// this test still passes — which is exactly what happened when Sonnet 4.5
+	// and Opus 4.5 were added. Pinning must be a deliberate step, not one that
+	// depends on remembering.
+	if len(cases) != len(modelToString) {
+		t.Errorf("%d models declared, %d pinned — add the new one's wire id here on purpose", len(modelToString), len(cases))
 	}
 	for m, want := range cases {
 		if got := m.String(); got != want {
@@ -469,6 +478,9 @@ func TestProviderKeys_AreStable(t *testing.T) {
 		GoogleVertex:          "google-vertex",
 		AnthropicSubscription: "anthropic-subscription",
 		OpenAIDirect:          "openai-direct",
+	}
+	if len(want) != len(providerKey) {
+		t.Errorf("%d providers have keys, %d pinned — a new slug must be pinned deliberately", len(providerKey), len(want))
 	}
 	for p, k := range want {
 		if got := p.Key(); got != k {
@@ -967,11 +979,15 @@ func TestAgentType_ValidityIsMembershipNotARange(t *testing.T) {
 // The round-trip test above only proves self-consistency; it would pass if
 // every literal changed together. This pins the literals themselves.
 func TestAgentType_WireStringsAreStable(t *testing.T) {
-	for h, want := range map[AgentType]string{
+	pinned := map[AgentType]string{
 		ClaudeCode: "claude-code",
 		Codex:      "codex",
 		Opencode:   "opencode",
-	} {
+	}
+	if len(pinned) != len(agentTypeToString) {
+		t.Errorf("%d agents declared, %d pinned — agentbox switches on these literals, so a new one must be pinned deliberately", len(agentTypeToString), len(pinned))
+	}
+	for h, want := range pinned {
 		if got := h.String(); got != want {
 			t.Errorf("%v.String() = %q, want %q — stored Tasks and agentbox both read this literal", h, got, want)
 		}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -780,3 +780,35 @@ func TestAgentType_EveryAgentHasADisplayName(t *testing.T) {
 		t.Error("opencode has no interactive mode in agentbox")
 	}
 }
+
+// Bedrock availability lags the direct API and varies by account and region.
+// The version-pinned prefixes mean a 4.6 request will NOT fall back to a 4.5
+// profile — correct, but it leaves an org whose Bedrock only has 4.5 unable to
+// run any Claude model there unless the catalogue carries the older version
+// too. This pins that the pair coexist without shadowing each other.
+func TestCatalog_GenerationsCoexistWithoutShadowing(t *testing.T) {
+	pairs := []struct{ older, newer Model }{
+		{ClaudeSonnet45, ClaudeSonnet46},
+		{ClaudeOpus45, ClaudeOpus48},
+	}
+	for _, p := range pairs {
+		o, n := p.older.BedrockProfilePrefix(), p.newer.BedrockProfilePrefix()
+		if o == "" || n == "" {
+			t.Errorf("%v/%v: both generations need a Bedrock prefix", p.older, p.newer)
+			continue
+		}
+		// Neither may be a prefix of the other, or discovery's Contains match
+		// would let one generation resolve to the other's profile — the silent
+		// wrong-model swap the pinning exists to prevent.
+		if strings.HasPrefix(o, n) || strings.HasPrefix(n, o) {
+			t.Errorf("%q and %q overlap; discovery could resolve one to the other", o, n)
+		}
+		// Both must be offered by the same agents, or picking the older one
+		// silently changes which harness runs.
+		for _, at := range AllAgentTypes() {
+			if at.Supports(p.newer) != at.Supports(p.older) {
+				t.Errorf("%v supports %v but not %v; the generations must be interchangeable", at, p.newer, p.older)
+			}
+		}
+	}
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -903,3 +903,25 @@ func TestNothingDependsOnDeclarationOrder(t *testing.T) {
 		t.Errorf("PreferredProvider = %v, want the subscription regardless of order", got)
 	}
 }
+
+// AllAgentTypes feeds the agent picker, so its order is USER-VISIBLE. Ranking
+// it by value would put the enum's declaration order on screen — the same
+// dependency AgentTypesFor stopped carrying.
+func TestAllAgentTypes_IsPriorityOrderedNotNumeric(t *testing.T) {
+	got := AllAgentTypes()
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Priority() > got[i].Priority() {
+			t.Errorf("AllAgentTypes is not priority-ordered: %v", got)
+		}
+	}
+	// And AgentTypesFor inherits it — a model several agents run must report
+	// the highest-priority one first, since callers take [0] as the harness.
+	for _, m := range []Model{ClaudeSonnet46, ClaudeHaiku45} {
+		agents := AgentTypesFor(m)
+		for i := 1; i < len(agents); i++ {
+			if agents[i-1].Priority() > agents[i].Priority() {
+				t.Errorf("AgentTypesFor(%v) is not priority-ordered: %v", m, agents)
+			}
+		}
+	}
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -858,3 +858,48 @@ func TestModelsFor_LegacySortsLastWithoutDisturbingCapabilityOrder(t *testing.T)
 		t.Errorf("agentTypeToModels[ClaudeCode] ends with legacy %v; high complexity would pick it", lineup[len(lineup)-1])
 	}
 }
+
+// NOTHING may depend on enum declaration order. Every ranking is an explicit
+// rule, so renumbering or inserting a constant cannot silently change which
+// agent runs a Task, which model a complexity resolves to, or which provider
+// serves a model.
+//
+// The renumbering here is the test: it swaps the values the old
+// order-dependent code leaned on, and every answer must be unchanged.
+func TestNothingDependsOnDeclarationOrder(t *testing.T) {
+	// Agent priority is a map, not the enum's order.
+	if ClaudeCode.Priority() >= Opencode.Priority() {
+		t.Error("claude-code must outrank opencode for a shared model")
+	}
+	// A model both can run resolves to the higher-priority agent regardless of
+	// which constant is numerically smaller.
+	agents := AgentTypesFor(ClaudeSonnet46)
+	if len(agents) == 0 || agents[0] != ClaudeCode {
+		t.Errorf("AgentTypesFor(Sonnet 4.6) = %v, want claude-code first", agents)
+	}
+
+	// Tier is a property, so a complexity maps to a band rather than to a list
+	// index — the whole point being that today's frontier model is tomorrow's
+	// balanced one, and re-tagging it is an edit rather than a reshuffle.
+	if got := ModelForTier(ClaudeCode, TierFast); got != ClaudeHaiku45 {
+		t.Errorf("fast tier = %v, want Haiku 4.5", got)
+	}
+	if got := ModelForTier(ClaudeCode, TierFrontier); got.IsLegacy() {
+		t.Errorf("frontier tier = %v, a superseded model", got)
+	}
+	// An untiered lineup resolves to the agent's explicit default rather than
+	// to whichever model is listed first.
+	if got := ModelForTier(Codex, TierBalanced); got != Codex.DefaultModel() {
+		t.Errorf("codex balanced = %v, want its default %v", got, Codex.DefaultModel())
+	}
+
+	// Provider preference is a rule; passing candidates in the WORST order
+	// must not change the answer.
+	worst := []Provider{AnthropicDirect, AWSBedrock, AnthropicSubscription}
+	got, ok := PreferredProvider(worst, func(p Provider) bool {
+		return p == AnthropicDirect || p == AnthropicSubscription
+	})
+	if !ok || got != AnthropicSubscription {
+		t.Errorf("PreferredProvider = %v, want the subscription regardless of order", got)
+	}
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -953,3 +953,32 @@ func TestAgentType_ValidityIsMembershipNotARange(t *testing.T) {
 		}
 	}
 }
+
+// These strings are the PERSISTED form and a container switch, in that order
+// of danger:
+//
+//	Mongo     Task.AgentType stores "claude-code"; a rename orphans every
+//	          existing Task, which then resolves to the default harness.
+//	agentbox  its config switches on these exact literals to pick a driver,
+//	          and it is a separate repo — a rename here compiles fine and
+//	          fails at spawn.
+//	wire      the AGENT_TYPE env var and the dashboard's agentType field.
+//
+// The round-trip test above only proves self-consistency; it would pass if
+// every literal changed together. This pins the literals themselves.
+func TestAgentType_WireStringsAreStable(t *testing.T) {
+	for h, want := range map[AgentType]string{
+		ClaudeCode: "claude-code",
+		Codex:      "codex",
+		Opencode:   "opencode",
+	} {
+		if got := h.String(); got != want {
+			t.Errorf("%v.String() = %q, want %q — stored Tasks and agentbox both read this literal", h, got, want)
+		}
+	}
+	// Empty resolves to claude-code: Tasks created before the agent type
+	// existed have no value stored, and agentbox applies the same default.
+	if got, err := ResolveAgentType(""); err != nil || got != ClaudeCode {
+		t.Errorf(`ResolveAgentType("") = %v (%v), want claude-code — legacy Tasks store nothing`, got, err)
+	}
+}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -139,7 +139,7 @@ func TestHarness_ResolveDefaultsEmptyToClaudeCode(t *testing.T) {
 func TestCatalog_EveryHarnessModelPairHasAtLeastOneProvider(t *testing.T) {
 	// A harness listing a model it can never actually be served is an offer the
 	// product cannot honour — the user picks it and the task fails at spawn.
-	for h := ClaudeCode; h < MaxAgentType; h++ {
+	for _, h := range AllAgentTypes() {
 		for _, m := range h.Models() {
 			if got := ProvidersFor(h, m); len(got) == 0 {
 				t.Errorf("%s lists model %s but no provider can serve it — agentTypeToProviders and modelToProviders disagree", h, m)
@@ -239,7 +239,7 @@ func TestCatalog_SubscriptionIsClaudeCodeOnly(t *testing.T) {
 	// genuine `claude` CLI is what passes Anthropic's client-identity check, so
 	// this is prohibited rather than merely unsupported. If the table ever
 	// offered it elsewhere, the UI would present an option the runner drops.
-	for h := ClaudeCode; h < MaxAgentType; h++ {
+	for _, h := range AllAgentTypes() {
 		for _, p := range h.Providers() {
 			if p == AnthropicSubscription && h != ClaudeCode {
 				t.Errorf("%s lists AnthropicSubscription; only claude-code may use it", h)
@@ -922,6 +922,34 @@ func TestAllAgentTypes_IsPriorityOrderedNotNumeric(t *testing.T) {
 			if agents[i-1].Priority() > agents[i].Priority() {
 				t.Errorf("AgentTypesFor(%v) is not priority-ordered: %v", m, agents)
 			}
+		}
+	}
+}
+
+// The agent enum is NOT persisted — Task.AgentType stores the string
+// "claude-code" — so the numbers are free to move. What is not free is a
+// sentinel: a hand-bumped MaxAgentType made adding an agent read as INVALID
+// until someone remembered, and a reserved value read as valid. Validity is
+// membership now, exactly as Provider's is.
+func TestAgentType_ValidityIsMembershipNotARange(t *testing.T) {
+	for _, h := range AllAgentTypes() {
+		if !h.IsValid() {
+			t.Errorf("%v is declared but not valid", h)
+		}
+	}
+	// A value past the declared set must be invalid — a range check with a
+	// stale sentinel would have accepted it.
+	if AgentType(99).IsValid() {
+		t.Error("an undeclared agent must not be valid")
+	}
+	if AgentType(0).IsValid() {
+		t.Error("the zero value must not be valid")
+	}
+	// And the string is what persists, so it must round-trip.
+	for _, h := range AllAgentTypes() {
+		got, err := ResolveAgentType(h.String())
+		if err != nil || got != h {
+			t.Errorf("%v does not round-trip through its wire string: got %v (%v)", h, got, err)
 		}
 	}
 }

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -245,3 +245,21 @@ func (m Model) DisplayName() string {
 	}
 	return m.String()
 }
+
+// legacyModels are superseded by a newer generation but kept offerable.
+//
+// They exist because BEDROCK AVAILABILITY LAGS the direct API: an account with
+// Sonnet 4.5 and not 4.6 needs the older entry to run anything at all, since
+// the profile prefixes are version-pinned and refuse to cross generations.
+//
+// A DISPLAY concern only. It must not touch agentTypeToModels' order, which is
+// capability-ascending and indexed by kit's recommendedByComplexity — sorting
+// legacy to the end of that list would make "high complexity" resolve to Opus
+// 4.5. ModelsFor applies the ordering instead, where it affects pickers alone.
+var legacyModels = map[Model]bool{
+	ClaudeSonnet45: true,
+	ClaudeOpus45:   true,
+}
+
+// IsLegacy reports whether a newer generation of this model exists.
+func (m Model) IsLegacy() bool { return legacyModels[m] }

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -30,6 +30,16 @@ const (
 	// non-Anthropic, non-OpenAI model, which is what the vendor axis was
 	// added for.
 	NovaProV1
+	// The 4.5-generation Claude models. Kept in the catalogue because BEDROCK
+	// AVAILABILITY LAGS the direct API and varies by account and region: an org
+	// whose Bedrock has Sonnet 4.5 but not 4.6 could otherwise run no Claude
+	// model there at all, since the profile prefixes are version-pinned and 4.6
+	// deliberately will not match a 4.5 profile.
+	//
+	// Ordinary catalogue models, not a Bedrock special case — the direct API
+	// still serves them, and pinning an older version is a legitimate choice.
+	ClaudeSonnet45
+	ClaudeOpus45
 
 	MaxModel // always add models before MaxModel
 )
@@ -45,6 +55,8 @@ var modelToString = map[Model]string{
 	Gpt53Codex:     "gpt-5.3-codex",
 	Gpt54:          "gpt-5.4",
 	NovaProV1:      "nova-pro-v1",
+	ClaudeSonnet45: "claude-sonnet-4-5",
+	ClaudeOpus45:   "claude-opus-4-5",
 }
 
 var stringToModel = func() map[string]Model {
@@ -105,7 +117,9 @@ var modelToBedrockProfilePrefix = map[Model]string{
 	ClaudeOpus48:   "claude-opus-4-8",
 	// Matches ids like eu.amazon.nova-pro-v1:0 — the vendor and region
 	// segments come from the profile id that discovery returns.
-	NovaProV1: "nova-pro-v1",
+	NovaProV1:      "nova-pro-v1",
+	ClaudeSonnet45: "claude-sonnet-4-5",
+	ClaudeOpus45:   "claude-opus-4-5",
 }
 
 // BedrockProfilePrefix returns the version-pinned prefix for a model, or ""
@@ -161,6 +175,8 @@ var modelToVendor = map[Model]Vendor{
 	Gpt53Codex:     VendorOpenAI,
 	Gpt54:          VendorOpenAI,
 	NovaProV1:      VendorAmazon,
+	ClaudeSonnet45: VendorAnthropic,
+	ClaudeOpus45:   VendorAnthropic,
 }
 
 // Vendor returns who makes this model, independent of how it is reached.
@@ -217,6 +233,8 @@ var modelToDisplayName = map[Model]string{
 	Gpt53Codex:     "GPT-5.3 Codex",
 	Gpt54:          "GPT-5.4",
 	NovaProV1:      "Nova Pro",
+	ClaudeSonnet45: "Sonnet 4.5",
+	ClaudeOpus45:   "Opus 4.5",
 }
 
 // DisplayName returns the human-facing name, falling back to the wire id so an

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -263,3 +263,96 @@ var legacyModels = map[Model]bool{
 
 // IsLegacy reports whether a newer generation of this model exists.
 func (m Model) IsLegacy() bool { return legacyModels[m] }
+
+// Tier is how capable a model is, independent of when it shipped.
+//
+// A PROPERTY OF THE MODEL, not its position in a list. Recommendation used to
+// index into agentTypeToModels — first entry for a simple task, last for a
+// complex one — which quietly required that list to stay capability-ascending
+// forever. Two things break that: adding an older generation (Sonnet 4.5 sits
+// between Haiku and Sonnet 4.6 by capability, not by release date), and the
+// passage of time. Today's frontier model is next year's balanced one, and
+// re-tagging it should be an edit HERE rather than a silent reshuffle of a
+// list that several other things read.
+type Tier uint
+
+const (
+	TierUnknown Tier = iota
+	// TierFast — cheapest and quickest; enough for mechanical work.
+	TierFast
+	// TierBalanced — the default choice for most tasks.
+	TierBalanced
+	// TierFrontier — the most capable available, for genuinely hard work.
+	TierFrontier
+
+	MaxTier
+)
+
+var tierToString = map[Tier]string{
+	TierFast:     "fast",
+	TierBalanced: "balanced",
+	TierFrontier: "frontier",
+}
+
+func (t Tier) String() string { return tierToString[t] }
+
+// modelToTier states each model's capability band.
+//
+// EXPECTED TO CHANGE as newer generations arrive — that is the point. When a
+// frontier model is superseded it moves down a band here, and every caller
+// follows without any list being reordered.
+var modelToTier = map[Model]Tier{
+	ClaudeHaiku45:  TierFast,
+	ClaudeSonnet45: TierBalanced,
+	ClaudeSonnet46: TierBalanced,
+	ClaudeOpus45:   TierFrontier,
+	ClaudeOpus48:   TierFrontier,
+	// The codex lineup is not cleanly tiered — 5.3-codex is task-specialised
+	// rather than weaker — so all three sit at balanced and the recommendation
+	// falls back to the agent's default.
+	Gpt55:      TierBalanced,
+	Gpt53Codex: TierBalanced,
+	Gpt54:      TierBalanced,
+	NovaProV1:  TierBalanced,
+}
+
+// Tier returns the model's capability band.
+func (m Model) Tier() Tier { return modelToTier[m] }
+
+// ModelForTier returns the model an agent should use at this tier, preferring
+// a current generation over a superseded one.
+//
+// Falls back to the agent's default when nothing matches, so a caller always
+// gets a usable model rather than an empty string — a tier with no model is a
+// catalogue gap, not something the caller should have to handle.
+func ModelForTier(h AgentType, t Tier) Model {
+	var current, legacy Model
+	for _, m := range agentTypeToModels[h] {
+		if m.Tier() != t {
+			continue
+		}
+		// The agent's own default wins its tier outright — an explicit choice
+		// beats any incidental one. This is what keeps a lineup that is not
+		// cleanly tiered (codex, where all three sit at balanced) from
+		// resolving to whichever model happened to be listed first.
+		if m == h.DefaultModel() {
+			return m
+		}
+		if m.IsLegacy() {
+			if legacy == 0 {
+				legacy = m
+			}
+			continue
+		}
+		if current == 0 {
+			current = m
+		}
+	}
+	switch {
+	case current != 0:
+		return current
+	case legacy != 0:
+		return legacy
+	}
+	return h.DefaultModel()
+}

--- a/enums/parameters_enums/keys_test.go
+++ b/enums/parameters_enums/keys_test.go
@@ -1,0 +1,57 @@
+package parameters_enums
+
+import (
+	"strconv"
+	"testing"
+)
+
+// Job parameters are PERSISTED as a map keyed by these strings —
+// job.Parameters is a map[string]interface{} in Mongo, and the runner reads
+// values back out by the same key. Changing one orphans that parameter on every
+// existing job: the value survives under the old key and is simply never read,
+// so the job runs with the field silently absent.
+//
+// This package had no tests at all, while carrying the most exposed strings in
+// the catalogue work.
+//
+// The contract is that a key's string IS its decimal value, which makes this
+// exhaustive BY CONSTRUCTION — it walks keyMap, so a key added tomorrow is
+// covered without anyone remembering to list it. That is deliberately stronger
+// than the hand-maintained pinning the model and provider tests use, where no
+// such relationship exists to lean on.
+func TestKeyStringsAreTheEnumValue(t *testing.T) {
+	if len(keyMap) == 0 {
+		t.Fatal("keyMap is empty; this test would pass vacuously")
+	}
+	for k, want := range keyMap {
+		if got := strconv.Itoa(int(k)); got != want {
+			t.Errorf("%s: keyMap says %q but the enum value is %s — the persisted key must be the value, or a typo silently orphans the parameter",
+				k.String(), want, got)
+		}
+		got, err := k.Key()
+		if err != nil || got != want {
+			t.Errorf("%s.Key() = %q, %v; want %q", k.String(), got, err, want)
+		}
+	}
+}
+
+// Two keys sharing a string would make one overwrite the other on every job —
+// last writer wins, and the loser reads back the wrong value rather than
+// nothing.
+func TestKeyStringsAreUnique(t *testing.T) {
+	seen := map[string]Key{}
+	for k, s := range keyMap {
+		if prev, dup := seen[s]; dup {
+			t.Errorf("key %q is shared by %s and %s; one would overwrite the other in job.Parameters", s, prev.String(), k.String())
+		}
+		seen[s] = k
+	}
+}
+
+// An unmapped key must ERROR rather than return "", which would write every
+// such parameter under the empty string and collide them all together.
+func TestUnmappedKeyErrors(t *testing.T) {
+	if _, err := Key(99999).Key(); err == nil {
+		t.Error("an unmapped key must error, not return an empty key")
+	}
+}


### PR DESCRIPTION
A live Claude-on-Bedrock test hit an account with **Sonnet 4.5 and Opus 4.5, but neither 4.6 nor 4.8** — so no Claude model in the catalogue could resolve there. Bedrock's model availability lags the direct API and varies by account and region, and customers will hit this too.

The version-pinned prefixes are the reason: `claude-sonnet-4-6` deliberately will **not** match a 4.5 profile, which is what stops a 4.6 request silently running 4.5. That guarantee is worth keeping — so the fix is to carry the older generation as real catalogue entries, not to loosen the matching.

Adds `ClaudeSonnet45` and `ClaudeOpus45`:

| | |
|---|---|
| wire ids | `claude-sonnet-4-5`, `claude-opus-4-5` |
| providers | Anthropic direct, subscription, Bedrock — same as their siblings |
| agents | claude-code and opencode — same as their siblings |

They are ordinary catalogue models, **not** a Bedrock special case: the direct API still serves them, and pinning an older version is a legitimate choice for reproducibility.

`TestCatalog_GenerationsCoexistWithoutShadowing` pins the property that matters: neither prefix may be a prefix of the other, or discovery's `Contains` match could resolve one generation to the other's profile — exactly the silent wrong-model swap the pinning exists to prevent. It also requires both generations to be offered by the same agents, so choosing the older one can't quietly change which harness runs.