### PR TITLE
Give opencode Bedrock's base model id, not the inference profile

### DIFF
--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -198,54 +198,49 @@ func (p Provider) OpencodeName() string {
 // (eu.amazon.nova-pro-v1:0) for the logical one. The provider prefix is what
 // opencode routes on, so it must survive that substitution.
 //
+// vendor decides whether a Bedrock id keeps its cross-region geography prefix,
+// and is why this takes a Vendor rather than sniffing the id's own vendor
+// segment: the rule is a fact about who MAKES the model, so the type that
+// already carries that fact should state it. Pass VendorUnknown when the model
+// is not in the catalogue and the id will be left alone.
+//
 // Returns "" when the provider has no opencode representation, so callers get
 // an empty result rather than a malformed "/model" string.
-func OpencodeModelID(modelID string, p Provider) string {
+func OpencodeModelID(modelID string, p Provider, vendor Vendor) string {
 	name := p.OpencodeName()
 	if name == "" || modelID == "" {
 		return ""
 	}
-	// opencode routes Bedrock through its own registry (models.dev), which is
-	// ASYMMETRIC about the cross-region geography prefix:
+	// opencode routes Bedrock through its own registry (models.dev), which
+	// carries geography-prefixed ids for some vendors and only base ids for
+	// others — see bedrockGeographyVendors for the split and the counts.
 	//
-	//   anthropic.*  base AND eu./us./au./jp./global. variants
-	//   amazon.*     base ONLY — no geography-prefixed entries at all
+	// Keeping the prefix matters where it belongs: for Anthropic the prefixed
+	// id IS the cross-region inference profile, which newer Claude models on
+	// Bedrock generally require, so dropping to the base id would silently ask
+	// for on-demand throughput they may not offer.
 	//
-	// So the prefix is stripped for Amazon's own models and KEPT for everyone
-	// else. Keeping it matters: for Anthropic the prefixed id IS the
-	// cross-region inference profile, which newer Claude models on Bedrock
-	// generally require — dropping to the base id would silently ask for
-	// on-demand throughput they may not offer.
-	//
-	// A live Nova run exposed this. Discovery resolved eu.amazon.nova-pro-v1:0
-	// and opencode rejected it with ProviderModelNotFoundError, suggesting
-	// amazon.nova-pro-v1:0.
+	// A live Nova run exposed the other direction. Discovery resolved
+	// eu.amazon.nova-pro-v1:0 and opencode rejected it with
+	// ProviderModelNotFoundError, suggesting amazon.nova-pro-v1:0.
 	//
 	// Only the geography goes; the dated revision stays, since that is what
 	// discovery exists to find.
-	if p == AWSBedrock {
-		modelID = stripBedrockGeographyForOpencode(modelID)
+	if p == AWSBedrock && !vendor.UsesBedrockGeographyPrefix() {
+		modelID = stripBedrockGeography(modelID)
 	}
 	return name + "/" + modelID
 }
 
-// stripBedrockGeographyForOpencode removes the cross-region prefix from an
-// Amazon-vendor Bedrock id, leaving every other vendor untouched.
+// stripBedrockGeography removes the cross-region prefix from a Bedrock id.
 //
-// Mirrors OPENCODE's registry, not Bedrock's: Bedrock does publish
-// eu.amazon.nova-pro-v1:0 — discovery finds it — but opencode has no entry for
-// it and cannot route it.
-func stripBedrockGeographyForOpencode(modelID string) string {
+// WHETHER to call this is the vendor's business, not this function's — it just
+// performs the removal.
+func stripBedrockGeography(modelID string) string {
 	for _, geo := range []string{"eu.", "us.", "au.", "jp.", "apac.", "global."} {
-		rest, found := strings.CutPrefix(modelID, geo)
-		if !found {
-			continue
-		}
-		// Only Amazon's own models lack geography-prefixed registry entries.
-		if strings.HasPrefix(rest, "amazon.") {
+		if rest, found := strings.CutPrefix(modelID, geo); found {
 			return rest
 		}
-		return modelID
 	}
 	return modelID
 }

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -205,38 +205,49 @@ func OpencodeModelID(modelID string, p Provider) string {
 	if name == "" || modelID == "" {
 		return ""
 	}
-	// opencode wants Bedrock's BASE model id, not the region-prefixed inference
-	// profile — it applies the geography itself. claude-code is the opposite: it
-	// takes the profile id verbatim. Same provider, same model, two renderings,
-	// which is why this belongs on the agent axis rather than the provider one.
+	// opencode routes Bedrock through its own registry (models.dev), which is
+	// ASYMMETRIC about the cross-region geography prefix:
 	//
-	// A live Nova run proved it: discovery resolved eu.amazon.nova-pro-v1:0 and
-	// opencode rejected it with ProviderModelNotFoundError, suggesting
-	// "amazon.nova-pro-v1:0".
+	//   anthropic.*  base AND eu./us./au./jp./global. variants
+	//   amazon.*     base ONLY — no geography-prefixed entries at all
 	//
-	// The prefix is stripped rather than the discovery skipped, because
-	// discovery is what finds the exact dated revision — anthropic's ids carry
-	// one (…claude-sonnet-4-5-20250929-v1:0) and hardcoding those would need a
-	// release per Bedrock model launch. Strip the geography, keep the version.
+	// So the prefix is stripped for Amazon's own models and KEPT for everyone
+	// else. Keeping it matters: for Anthropic the prefixed id IS the
+	// cross-region inference profile, which newer Claude models on Bedrock
+	// generally require — dropping to the base id would silently ask for
+	// on-demand throughput they may not offer.
+	//
+	// A live Nova run exposed this. Discovery resolved eu.amazon.nova-pro-v1:0
+	// and opencode rejected it with ProviderModelNotFoundError, suggesting
+	// amazon.nova-pro-v1:0.
+	//
+	// Only the geography goes; the dated revision stays, since that is what
+	// discovery exists to find.
 	if p == AWSBedrock {
-		modelID = strings.TrimPrefix(modelID, bedrockGeographyPrefix(modelID))
+		modelID = stripBedrockGeographyForOpencode(modelID)
 	}
 	return name + "/" + modelID
 }
 
-// bedrockGeographyPrefix returns the cross-region prefix on an inference
-// profile id, or "" when there is none.
+// stripBedrockGeographyForOpencode removes the cross-region prefix from an
+// Amazon-vendor Bedrock id, leaving every other vendor untouched.
 //
-// Matches the prefixes deployment-runner's discovery produces. Kept here
-// because the stripping is a catalogue-level rendering rule, and a caller that
-// re-derived it would be one more copy of Bedrock's naming scheme.
-func bedrockGeographyPrefix(modelID string) string {
-	for _, prefix := range []string{"eu.", "us.", "apac."} {
-		if strings.HasPrefix(modelID, prefix) {
-			return prefix
+// Mirrors OPENCODE's registry, not Bedrock's: Bedrock does publish
+// eu.amazon.nova-pro-v1:0 — discovery finds it — but opencode has no entry for
+// it and cannot route it.
+func stripBedrockGeographyForOpencode(modelID string) string {
+	for _, geo := range []string{"eu.", "us.", "au.", "jp.", "apac.", "global."} {
+		rest, found := strings.CutPrefix(modelID, geo)
+		if !found {
+			continue
 		}
+		// Only Amazon's own models lack geography-prefixed registry entries.
+		if strings.HasPrefix(rest, "amazon.") {
+			return rest
+		}
+		return modelID
 	}
-	return ""
+	return modelID
 }
 
 // ConfigurableProviders returns every provider an org can actually configure,

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -1,6 +1,9 @@
 package llm_provider_enums
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 // The catalogue: which (harness, model, provider) combinations are real.
 //
@@ -202,7 +205,38 @@ func OpencodeModelID(modelID string, p Provider) string {
 	if name == "" || modelID == "" {
 		return ""
 	}
+	// opencode wants Bedrock's BASE model id, not the region-prefixed inference
+	// profile — it applies the geography itself. claude-code is the opposite: it
+	// takes the profile id verbatim. Same provider, same model, two renderings,
+	// which is why this belongs on the agent axis rather than the provider one.
+	//
+	// A live Nova run proved it: discovery resolved eu.amazon.nova-pro-v1:0 and
+	// opencode rejected it with ProviderModelNotFoundError, suggesting
+	// "amazon.nova-pro-v1:0".
+	//
+	// The prefix is stripped rather than the discovery skipped, because
+	// discovery is what finds the exact dated revision — anthropic's ids carry
+	// one (…claude-sonnet-4-5-20250929-v1:0) and hardcoding those would need a
+	// release per Bedrock model launch. Strip the geography, keep the version.
+	if p == AWSBedrock {
+		modelID = strings.TrimPrefix(modelID, bedrockGeographyPrefix(modelID))
+	}
 	return name + "/" + modelID
+}
+
+// bedrockGeographyPrefix returns the cross-region prefix on an inference
+// profile id, or "" when there is none.
+//
+// Matches the prefixes deployment-runner's discovery produces. Kept here
+// because the stripping is a catalogue-level rendering rule, and a caller that
+// re-derived it would be one more copy of Bedrock's naming scheme.
+func bedrockGeographyPrefix(modelID string) string {
+	for _, prefix := range []string{"eu.", "us.", "apac."} {
+		if strings.HasPrefix(modelID, prefix) {
+			return prefix
+		}
+	}
+	return ""
 }
 
 // ConfigurableProviders returns every provider an org can actually configure,

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -38,10 +38,23 @@ import (
 // point of keeping Model logical — see PLAN_provider_centric_llm_keys.md §3.3
 // and §4.1, where the prefix's second job (disambiguating the harness) is what
 // made stripping it dangerous until AgentType became explicit.
+// ⚠️ ORDER IS LOAD-BEARING and new entries go at the END. ModelForTier walks
+// this list and takes the first non-legacy match, so inserting a model
+// mid-list silently changes what "high complexity" resolves to for every
+// existing Task. Appending cannot: Opus 4.8 stays the frontier answer for
+// claude-code and opencode even with Opus 5 now in the catalogue, and moving
+// that on should be a deliberate edit to modelToTier, not a side effect of
+// adding a model.
 var agentTypeToModels = map[AgentType][]Model{
-	ClaudeCode: {ClaudeHaiku45, ClaudeSonnet45, ClaudeSonnet46, ClaudeOpus45, ClaudeOpus48},
-	Codex:      {Gpt55, Gpt53Codex, Gpt54},
-	Opencode:   {ClaudeHaiku45, ClaudeSonnet45, ClaudeSonnet46, ClaudeOpus45, ClaudeOpus48, Gpt55, NovaProV1},
+	ClaudeCode: {ClaudeHaiku45, ClaudeSonnet45, ClaudeSonnet46, ClaudeOpus45, ClaudeOpus48,
+		ClaudeSonnet5, ClaudeOpus5, ClaudeFable5},
+	Codex: {Gpt55, Gpt53Codex, Gpt54},
+	Opencode: {ClaudeHaiku45, ClaudeSonnet45, ClaudeSonnet46, ClaudeOpus45, ClaudeOpus48, Gpt55, NovaProV1,
+		ClaudeSonnet5, ClaudeOpus5, ClaudeFable5,
+		// The Bedrock-only lineup. opencode is the only agent that can reach
+		// these: claude-code and codex each speak one vendor's API, while
+		// opencode routes by provider id — which is the reason it exists here.
+		Qwen3Coder480B, Qwen3CoderNext, DeepSeekV32, Glm47, Glm5, MinimaxM25, Grok43},
 }
 
 // modelToProviders lists which providers can serve each model.
@@ -66,6 +79,20 @@ var modelToProviders = map[Model][]Provider{
 	// subscription still serve them, and Bedrock is where they matter most.
 	ClaudeSonnet45: {AnthropicDirect, AnthropicSubscription, AWSBedrock},
 	ClaudeOpus45:   {AnthropicDirect, AnthropicSubscription, AWSBedrock},
+	ClaudeSonnet5:  {AnthropicDirect, AnthropicSubscription, AWSBedrock},
+	ClaudeOpus5:    {AnthropicDirect, AnthropicSubscription, AWSBedrock},
+	ClaudeFable5:   {AnthropicDirect, AnthropicSubscription, AWSBedrock},
+	// Bedrock-ONLY, like Nova and for the same reason: we have no direct
+	// provider for any of these vendors, so AWS is the whole route. An org
+	// without Bedrock configured will not see them at all — ModelsFor filters
+	// on what the org can actually serve.
+	Qwen3Coder480B: {AWSBedrock},
+	Qwen3CoderNext: {AWSBedrock},
+	DeepSeekV32:    {AWSBedrock},
+	Glm47:          {AWSBedrock},
+	Glm5:           {AWSBedrock},
+	MinimaxM25:     {AWSBedrock},
+	Grok43:         {AWSBedrock},
 }
 
 // agentProviderCapabilities lists which provider APIs each CLI can talk to.

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -131,8 +131,30 @@ var agentProviderCapabilities = map[AgentType][]Provider{
 	Opencode:   {AnthropicDirect, AWSBedrock, OpenAIDirect},
 }
 
-// Models returns the models this harness can run.
-func (h AgentType) Models() []Model { return agentTypeToModels[h] }
+// Models returns the models this harness OFFERS — retired ones excluded.
+//
+// Filtered here rather than at each call site because this is what every
+// offering path already reads, kit's SupportedModels and IsModelSupported
+// included. A disabled model therefore stops being creatable without kit
+// needing to learn the concept.
+//
+// Use AllModels when the question is capability or history rather than what to
+// offer.
+func (h AgentType) Models() []Model {
+	out := make([]Model, 0, len(agentTypeToModels[h]))
+	for _, m := range agentTypeToModels[h] {
+		if !m.IsDisabled() {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// AllModels returns every model this harness can run, INCLUDING retired ones.
+//
+// For callers asking what a harness is capable of, or rendering a model a Task
+// already holds. Offering paths want Models.
+func (h AgentType) AllModels() []Model { return agentTypeToModels[h] }
 
 // Providers returns the provider APIs this harness can talk to. Order carries
 // NO preference — see PreferredProvider.
@@ -143,6 +165,11 @@ func (h AgentType) Providers() []Provider { return agentProviderCapabilities[h] 
 func (m Model) Providers() []Provider { return modelToProviders[m] }
 
 // Supports reports whether the harness can run the model at all.
+//
+// Deliberately reads the FULL list, retired models included: a Task already
+// holding a disabled model is still runnable, and this answers capability
+// rather than what to offer. ProvidersFor depends on it, which is what keeps a
+// disabled model resolving at spawn instead of failing as "not possible".
 func (h AgentType) Supports(m Model) bool {
 	for _, candidate := range agentTypeToModels[h] {
 		if candidate == m {
@@ -377,7 +404,7 @@ func (h AgentType) DefaultModel() Model { return agentTypeToDefaultModel[h] }
 // learn what an organization is.
 func ModelsFor(h AgentType, isConfigured func(Provider) bool) []Model {
 	var out []Model
-	for _, m := range agentTypeToModels[h] {
+	for _, m := range h.Models() {
 		for _, p := range ProvidersFor(h, m) {
 			if isConfigured(p) {
 				out = append(out, m)

--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -213,7 +213,7 @@ func OpencodeModelID(modelID string, p Provider, vendor Vendor) string {
 	}
 	// opencode routes Bedrock through its own registry (models.dev), which
 	// carries geography-prefixed ids for some vendors and only base ids for
-	// others — see bedrockGeographyVendors for the split and the counts.
+	// others — see opencodeBedrockGeographyVendors for the split and the counts.
 	//
 	// Keeping the prefix matters where it belongs: for Anthropic the prefixed
 	// id IS the cross-region inference profile, which newer Claude models on
@@ -226,7 +226,7 @@ func OpencodeModelID(modelID string, p Provider, vendor Vendor) string {
 	//
 	// Only the geography goes; the dated revision stays, since that is what
 	// discovery exists to find.
-	if p == AWSBedrock && !vendor.UsesBedrockGeographyPrefix() {
+	if p == AWSBedrock && !vendor.OpencodeKeepsBedrockGeography() {
 		modelID = stripBedrockGeography(modelID)
 	}
 	return name + "/" + modelID

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -347,23 +347,27 @@ func TestOpencodeModelID_RendersProviderPrefix(t *testing.T) {
 		{"claude-sonnet-4-6", AnthropicDirect, "anthropic/claude-sonnet-4-6"},
 		{"gpt-5.5", OpenAIDirect, "openai/gpt-5.5"},
 		{"nova-pro-v1", AWSBedrock, "amazon-bedrock/nova-pro-v1"},
-		// The runner substitutes the discovered profile id before rendering, and
-		// opencode wants Bedrock's BASE id — it applies the geography itself.
-		// This case previously asserted the prefix survived, which is what a
-		// live Nova run disproved: opencode rejected
-		// "amazon-bedrock/eu.amazon.nova-pro-v1:0" with
-		// ProviderModelNotFoundError, suggesting "amazon.nova-pro-v1:0".
+
+		// Amazon's own models have NO geography-prefixed entries in opencode's
+		// registry, so the prefix discovery found must come off. This is the
+		// case a live Nova run failed on.
 		{"eu.amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
-		// The VERSION must survive the strip — only the geography goes. Losing
-		// the dated revision would put us back to guessing which one Bedrock
-		// has, which is the whole reason discovery exists.
+		{"us.amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
+
+		// Anthropic's ARE in the registry prefixed, and the prefixed id IS the
+		// cross-region inference profile — which newer Claude models on Bedrock
+		// generally require. Stripping here would quietly request on-demand
+		// throughput they may not offer, so it must pass through untouched.
 		{"eu.anthropic.claude-sonnet-4-5-20250929-v1:0", AWSBedrock,
-			"amazon-bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0"},
+			"amazon-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0"},
 		{"us.anthropic.claude-opus-4-5-20251101-v1:0", AWSBedrock,
-			"amazon-bedrock/anthropic.claude-opus-4-5-20251101-v1:0"},
-		{"apac.amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
-		// Only Bedrock strips — a vendor id that happens to start with a
-		// geography-looking token elsewhere must be left alone.
+			"amazon-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0"},
+
+		// An id that already carries no geography is left alone either way.
+		{"amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
+
+		// Only Bedrock is touched — a vendor id starting with a
+		// geography-looking token elsewhere must survive.
 		{"eu.something", AnthropicDirect, "anthropic/eu.something"},
 	}
 	for _, c := range cases {

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -342,37 +342,94 @@ func TestOpencodeModelID_RendersProviderPrefix(t *testing.T) {
 	cases := []struct {
 		model    string
 		provider Provider
+		vendor   Vendor
 		want     string
 	}{
-		{"claude-sonnet-4-6", AnthropicDirect, "anthropic/claude-sonnet-4-6"},
-		{"gpt-5.5", OpenAIDirect, "openai/gpt-5.5"},
-		{"nova-pro-v1", AWSBedrock, "amazon-bedrock/nova-pro-v1"},
+		{"claude-sonnet-4-6", AnthropicDirect, VendorAnthropic, "anthropic/claude-sonnet-4-6"},
+		{"gpt-5.5", OpenAIDirect, VendorOpenAI, "openai/gpt-5.5"},
+		{"nova-pro-v1", AWSBedrock, VendorAmazon, "amazon-bedrock/nova-pro-v1"},
 
 		// Amazon's own models have NO geography-prefixed entries in opencode's
 		// registry, so the prefix discovery found must come off. This is the
 		// case a live Nova run failed on.
-		{"eu.amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
-		{"us.amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
+		{"eu.amazon.nova-pro-v1:0", AWSBedrock, VendorAmazon, "amazon-bedrock/amazon.nova-pro-v1:0"},
+		{"us.amazon.nova-pro-v1:0", AWSBedrock, VendorAmazon, "amazon-bedrock/amazon.nova-pro-v1:0"},
 
 		// Anthropic's ARE in the registry prefixed, and the prefixed id IS the
 		// cross-region inference profile — which newer Claude models on Bedrock
 		// generally require. Stripping here would quietly request on-demand
 		// throughput they may not offer, so it must pass through untouched.
-		{"eu.anthropic.claude-sonnet-4-5-20250929-v1:0", AWSBedrock,
+		{"eu.anthropic.claude-sonnet-4-5-20250929-v1:0", AWSBedrock, VendorAnthropic,
 			"amazon-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0"},
-		{"us.anthropic.claude-opus-4-5-20251101-v1:0", AWSBedrock,
+		{"us.anthropic.claude-opus-4-5-20251101-v1:0", AWSBedrock, VendorAnthropic,
 			"amazon-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0"},
 
 		// An id that already carries no geography is left alone either way.
-		{"amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
+		{"amazon.nova-pro-v1:0", AWSBedrock, VendorAmazon, "amazon-bedrock/amazon.nova-pro-v1:0"},
 
-		// Only Bedrock is touched — a vendor id starting with a
-		// geography-looking token elsewhere must survive.
-		{"eu.something", AnthropicDirect, "anthropic/eu.something"},
+		// A model outside the catalogue has no vendor, and an unknown vendor
+		// must not be rewritten on a guess.
+		{"eu.acme.something-v1:0", AWSBedrock, VendorUnknown,
+			"amazon-bedrock/eu.acme.something-v1:0"},
+
+		// Only Bedrock is touched — an id starting with a geography-looking
+		// token at another provider must survive.
+		{"eu.something", AnthropicDirect, VendorAnthropic, "anthropic/eu.something"},
+		{"eu.something", OpenAIDirect, VendorAmazon, "openai/eu.something"},
 	}
 	for _, c := range cases {
-		if got := OpencodeModelID(c.model, c.provider); got != c.want {
-			t.Errorf("OpencodeModelID(%q, %s) = %q, want %q", c.model, c.provider, got, c.want)
+		if got := OpencodeModelID(c.model, c.provider, c.vendor); got != c.want {
+			t.Errorf("OpencodeModelID(%q, %s, %v) = %q, want %q", c.model, c.provider, c.vendor, got, c.want)
+		}
+	}
+}
+
+// Every geography AWS uses must be recognised, for a vendor that strips. A
+// prefix missing from the list is a silent pass-through: the id keeps its
+// geography, opencode has no entry for it, and the run fails at spawn.
+func TestOpencodeModelID_StripsEveryGeography(t *testing.T) {
+	for _, geo := range []string{"eu.", "us.", "au.", "jp.", "apac.", "global."} {
+		got := OpencodeModelID(geo+"amazon.nova-pro-v1:0", AWSBedrock, VendorAmazon)
+		if want := "amazon-bedrock/amazon.nova-pro-v1:0"; got != want {
+			t.Errorf("geography %q: got %q, want %q", geo, got, want)
+		}
+	}
+}
+
+// The strip decision belongs to the vendor, so it must follow the VENDOR
+// argument rather than the id's own vendor segment. These two disagree on
+// purpose: a caller that passed the wrong vendor should produce the wrong
+// answer here, which is what makes the argument load-bearing rather than
+// decorative.
+func TestOpencodeModelID_FollowsVendorArgNotTheIDText(t *testing.T) {
+	if got := OpencodeModelID("eu.amazon.nova-pro-v1:0", AWSBedrock, VendorAnthropic); got !=
+		"amazon-bedrock/eu.amazon.nova-pro-v1:0" {
+		t.Errorf("VendorAnthropic should keep the prefix, got %q", got)
+	}
+	if got := OpencodeModelID("eu.anthropic.claude-sonnet-4-5-20250929-v1:0", AWSBedrock, VendorAmazon); got !=
+		"amazon-bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0" {
+		t.Errorf("VendorAmazon should strip the prefix, got %q", got)
+	}
+}
+
+// Every model the catalogue offers on Bedrock must have a vendor whose strip
+// rule was actually considered. Adding a Bedrock-hosted model from a new vendor
+// fails HERE, at CI, rather than at spawn on a customer's runner — which is the
+// whole reason the rule hangs off the Vendor enum.
+func TestBedrockModelsHaveAConsideredGeographyRule(t *testing.T) {
+	considered := map[Vendor]bool{
+		VendorAnthropic: true, // keeps  — 45 prefixed entries in models.dev
+		VendorAmazon:    true, // strips —  0 prefixed entries
+	}
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		if m.BedrockProfilePrefix() == "" {
+			continue // not served by Bedrock
+		}
+		if !considered[m.Vendor()] {
+			t.Errorf("model %s is on Bedrock but vendor %v has no considered "+
+				"geography rule — check models.dev for whether opencode lists "+
+				"its ids prefixed, then add it here and to bedrockGeographyVendors",
+				m, m.Vendor())
 		}
 	}
 }
@@ -383,14 +440,14 @@ func TestOpencodeModelID_EmptyForProvidersOpencodeCannotUse(t *testing.T) {
 	// unsupported. agentTypeToProviders already excludes it; returning "" here is
 	// the second line of defence, so a caller that skips that check still
 	// cannot build a usable id.
-	if got := OpencodeModelID("claude-opus-4-8", AnthropicSubscription); got != "" {
+	if got := OpencodeModelID("claude-opus-4-8", AnthropicSubscription, VendorAnthropic); got != "" {
 		t.Errorf("OpencodeModelID with AnthropicSubscription = %q, want \"\"", got)
 	}
-	if got := OpencodeModelID("claude-opus-4-8", GoogleVertex); got != "" {
+	if got := OpencodeModelID("claude-opus-4-8", GoogleVertex, VendorAnthropic); got != "" {
 		t.Errorf("OpencodeModelID with GoogleVertex = %q, want \"\" (not wired)", got)
 	}
 	// A malformed "/model" is worse than nothing — it looks valid.
-	if got := OpencodeModelID("", AWSBedrock); got != "" {
+	if got := OpencodeModelID("", AWSBedrock, VendorAmazon); got != "" {
 		t.Errorf("OpencodeModelID with empty model = %q, want \"\"", got)
 	}
 }

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -107,6 +107,16 @@ func TestModel_WireStringsAreStable(t *testing.T) {
 		NovaProV1:      "nova-pro-v1",
 		ClaudeSonnet45: "claude-sonnet-4-5",
 		ClaudeOpus45:   "claude-opus-4-5",
+		ClaudeSonnet5:  "claude-sonnet-5",
+		ClaudeOpus5:    "claude-opus-5",
+		ClaudeFable5:   "claude-fable-5",
+		Qwen3Coder480B: "qwen3-coder-480b",
+		Qwen3CoderNext: "qwen3-coder-next",
+		DeepSeekV32:    "deepseek-v3.2",
+		Glm47:          "glm-4.7",
+		Glm5:           "glm-5",
+		MinimaxM25:     "minimax-m2.5",
+		Grok43:         "grok-4.3",
 	}
 	// EXHAUSTIVE. Without this, adding a model leaves its wire id unpinned and
 	// this test still passes — which is exactly what happened when Sonnet 4.5
@@ -157,11 +167,19 @@ func TestCatalog_EveryHarnessModelPairHasAtLeastOneProvider(t *testing.T) {
 	}
 }
 
-func TestCatalog_BedrockModelsAllHaveAProfilePrefix(t *testing.T) {
-	// modelToProviders claiming AWSBedrock without a prefix means discovery has
-	// nothing to match on, and the logical id reaches Bedrock verbatim — the
-	// exact failure the live smoke test produced ("The provided model
-	// identifier is invalid").
+// A Bedrock model reaches its concrete id one of TWO ways, and must declare
+// exactly one of them.
+//
+//	profile prefix   — a cross-region inference profile exists; discovery
+//	                   resolves the dated revision at run time
+//	declared id      — no profile exists (the Qwen/DeepSeek/GLM/MiniMax/Grok
+//	                   lineup), so the id is stated in modelProviderID
+//
+// NEITHER means the logical id reaches Bedrock verbatim — "The provided model
+// identifier is invalid", which is how the first live run failed. BOTH is a
+// contradiction: discovery would overwrite the declared id, so one of the two
+// statements is dead and nobody could tell which was intended.
+func TestCatalog_BedrockModelsDeclareExactlyOneIDMechanism(t *testing.T) {
 	for m := ClaudeHaiku45; m < MaxModel; m++ {
 		onBedrock := false
 		for _, p := range m.Providers() {
@@ -169,11 +187,47 @@ func TestCatalog_BedrockModelsAllHaveAProfilePrefix(t *testing.T) {
 				onBedrock = true
 			}
 		}
-		if onBedrock && m.BedrockProfilePrefix() == "" {
-			t.Errorf("model %s lists AWSBedrock but has no profile prefix; discovery cannot resolve it", m)
-		}
-		if !onBedrock && m.BedrockProfilePrefix() != "" {
+		prefix := m.BedrockProfilePrefix() != ""
+		declared := m.IDFor(AWSBedrock) != m.String()
+
+		switch {
+		case onBedrock && !prefix && !declared:
+			t.Errorf("model %s lists AWSBedrock but declares neither a profile prefix nor a Bedrock id; the logical id would reach the API verbatim", m)
+		case onBedrock && prefix && declared:
+			t.Errorf("model %s declares BOTH a profile prefix and a Bedrock id; discovery would overwrite the declared id, so one of them is dead", m)
+		case !onBedrock && prefix:
 			t.Errorf("model %s has a profile prefix but does not list AWSBedrock as a provider", m)
+		case !onBedrock && declared:
+			t.Errorf("model %s declares a Bedrock id but does not list AWSBedrock as a provider", m)
+		}
+	}
+}
+
+// The declared ids are what OPENCODE resolves against, so their shape is a
+// contract with models.dev rather than with Bedrock. Each must carry the
+// vendor segment models.dev uses — a bare "glm-5" is not findable there, and
+// that is precisely the class of failure the Nova run exposed.
+func TestCatalog_DeclaredBedrockIDsCarryTheirVendorSegment(t *testing.T) {
+	segment := map[Vendor]string{
+		VendorQwen:     "qwen.",
+		VendorDeepSeek: "deepseek.",
+		VendorZAI:      "zai.",
+		VendorMiniMax:  "minimax.",
+		VendorXAI:      "xai.",
+		VendorAmazon:   "amazon.",
+	}
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		id := m.IDFor(AWSBedrock)
+		if id == m.String() {
+			continue // resolved by discovery, not declared
+		}
+		want, ok := segment[m.Vendor()]
+		if !ok {
+			t.Errorf("model %s declares Bedrock id %q but its vendor %v has no known registry segment", m, id, m.Vendor())
+			continue
+		}
+		if !strings.HasPrefix(id, want) {
+			t.Errorf("declared Bedrock id for %s is %q, want it to start with %q — opencode looks it up in models.dev by that name", m, id, want)
 		}
 	}
 }
@@ -417,19 +471,57 @@ func TestOpencodeModelID_FollowsVendorArgNotTheIDText(t *testing.T) {
 // fails HERE, at CI, rather than at spawn on a customer's runner — which is the
 // whole reason the rule hangs off the Vendor enum.
 func TestBedrockModelsHaveAConsideredGeographyRule(t *testing.T) {
-	considered := map[Vendor]bool{
-		VendorAnthropic: true, // keeps  — 45 prefixed entries in models.dev
-		VendorAmazon:    true, // strips —  0 prefixed entries
+	// ⚠️ KEYED BY MODEL, NOT VENDOR, even though the RULE is vendor-level. Two
+	// vendors split per model in the registry — meta (llama3 bare, llama4 us.)
+	// and deepseek (v3.2 bare, r1 us.) — so a vendor-keyed guard would wave
+	// DeepSeek R1 through the moment V3.2 is present, and R1 would break
+	// silently. Model-keyed costs one line per model and cannot be outgrown.
+	const (
+		keep  = true  // models.dev carries geography-prefixed entries
+		strip = false // models.dev carries only the base id
+	)
+	considered := map[Model]bool{
+		ClaudeHaiku45:  keep,
+		ClaudeSonnet45: keep,
+		ClaudeSonnet46: keep,
+		ClaudeOpus45:   keep,
+		ClaudeOpus48:   keep,
+		ClaudeSonnet5:  keep,
+		ClaudeOpus5:    keep,
+		ClaudeFable5:   keep,
+		NovaProV1:      strip,
+		Qwen3Coder480B: strip,
+		Qwen3CoderNext: strip,
+		DeepSeekV32:    strip,
+		Glm47:          strip,
+		Glm5:           strip,
+		MinimaxM25:     strip,
+		Grok43:         strip,
 	}
 	for m := ClaudeHaiku45; m < MaxModel; m++ {
-		if m.BedrockProfilePrefix() == "" {
-			continue // not served by Bedrock
+		onBedrock := false
+		for _, p := range m.Providers() {
+			if p == AWSBedrock {
+				onBedrock = true
+			}
 		}
-		if !considered[m.Vendor()] {
-			t.Errorf("model %s is on Bedrock but vendor %v has no considered "+
-				"geography rule — check models.dev for whether opencode lists "+
-				"its ids prefixed, then add it here and to opencodeBedrockGeographyVendors",
-				m, m.Vendor())
+		if !onBedrock {
+			continue
+		}
+		want, ok := considered[m]
+		if !ok {
+			t.Errorf("model %s is on Bedrock but its geography rule was never "+
+				"checked — look it up in models.dev, then record it here and, if it "+
+				"needs keeping, in opencodeBedrockGeographyVendors", m)
+			continue
+		}
+		// The vendor-level rule must agree with what was checked per model. A
+		// mismatch means that vendor has split and the rule can no longer be
+		// stated vendor-wide.
+		if got := m.Vendor().OpencodeKeepsBedrockGeography(); got != want {
+			t.Errorf("model %s: vendor %v says keep=%v but the registry says keep=%v — "+
+				"this vendor now splits per model, so the rule needs a per-model override",
+				m, m.Vendor(), got, want)
 		}
 	}
 }
@@ -465,11 +557,19 @@ func TestOpencodeProviderNamesCoverEveryReachableProvider(t *testing.T) {
 }
 
 func TestIDFor_DefaultsToTheLogicalID(t *testing.T) {
-	// The override map is empty on purpose, so every model currently reports
-	// its logical id at every provider. This pins the FALLBACK, which is the
-	// behaviour that matters when no override exists.
+	// Overrides exist only for Bedrock, and only for the models with no
+	// inference profile. Everywhere else the logical id must come back
+	// unchanged — this pins the FALLBACK, which is what almost every lookup
+	// hits.
+	//
+	// Deliberately asserts on EVERY provider except that one pair, rather than
+	// listing the models expected to be clean: an override added to a second
+	// provider by accident fails here rather than at spawn.
 	for m := ClaudeHaiku45; m < MaxModel; m++ {
 		for _, p := range m.Providers() {
+			if p == AWSBedrock && m.BedrockProfilePrefix() == "" {
+				continue // declared id, covered by the two tests above
+			}
 			if got := m.IDFor(p); got != m.String() {
 				t.Errorf("IDFor(%s, %s) = %q, want the logical id %q", m, p, got, m)
 			}
@@ -498,17 +598,22 @@ func TestResolvesModelIDAtRuntime_IsAPropertyNotAProviderCheck(t *testing.T) {
 }
 
 func TestRuntimeResolvedProvidersHaveDiscoveryInput(t *testing.T) {
-	// A provider that resolves ids at runtime needs something to match on. For
-	// Bedrock that is the version-pinned profile prefix — without it discovery
-	// has nothing to search for and the logical id reaches the API verbatim,
-	// which is exactly how the first live run failed.
+	// A provider that resolves ids at runtime needs something to match on, OR a
+	// declared id to fall back to. Neither means the logical id reaches the API
+	// verbatim, which is exactly how the first live run failed.
+	//
+	// ResolvesModelIDAtRuntime is a property of the PROVIDER, so it stays true
+	// for Bedrock even for models that have nothing to discover. That is not a
+	// contradiction: discovery runs, finds no profile, logs it, and leaves the
+	// declared id in place — see applyAgentModelEnv, which only overwrites on a
+	// non-empty result.
 	for m := ClaudeHaiku45; m < MaxModel; m++ {
 		for _, p := range m.Providers() {
-			if !p.ResolvesModelIDAtRuntime() {
+			if !p.ResolvesModelIDAtRuntime() || p != AWSBedrock {
 				continue
 			}
-			if p == AWSBedrock && m.BedrockProfilePrefix() == "" {
-				t.Errorf("%s is served by %s, which resolves ids at runtime, but it has no profile prefix to discover with", m, p)
+			if m.BedrockProfilePrefix() == "" && m.IDFor(p) == m.String() {
+				t.Errorf("%s is served by %s, which resolves ids at runtime, but it has neither a profile prefix to discover with nor a declared id to fall back to", m, p)
 			}
 		}
 	}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -428,7 +428,7 @@ func TestBedrockModelsHaveAConsideredGeographyRule(t *testing.T) {
 		if !considered[m.Vendor()] {
 			t.Errorf("model %s is on Bedrock but vendor %v has no considered "+
 				"geography rule — check models.dev for whether opencode lists "+
-				"its ids prefixed, then add it here and to bedrockGeographyVendors",
+				"its ids prefixed, then add it here and to opencodeBedrockGeographyVendors",
 				m, m.Vendor())
 		}
 	}

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -347,9 +347,24 @@ func TestOpencodeModelID_RendersProviderPrefix(t *testing.T) {
 		{"claude-sonnet-4-6", AnthropicDirect, "anthropic/claude-sonnet-4-6"},
 		{"gpt-5.5", OpenAIDirect, "openai/gpt-5.5"},
 		{"nova-pro-v1", AWSBedrock, "amazon-bedrock/nova-pro-v1"},
-		// The runner substitutes the discovered profile id before rendering, so
-		// the prefix must survive a model string the catalogue never held.
-		{"eu.amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/eu.amazon.nova-pro-v1:0"},
+		// The runner substitutes the discovered profile id before rendering, and
+		// opencode wants Bedrock's BASE id — it applies the geography itself.
+		// This case previously asserted the prefix survived, which is what a
+		// live Nova run disproved: opencode rejected
+		// "amazon-bedrock/eu.amazon.nova-pro-v1:0" with
+		// ProviderModelNotFoundError, suggesting "amazon.nova-pro-v1:0".
+		{"eu.amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
+		// The VERSION must survive the strip — only the geography goes. Losing
+		// the dated revision would put us back to guessing which one Bedrock
+		// has, which is the whole reason discovery exists.
+		{"eu.anthropic.claude-sonnet-4-5-20250929-v1:0", AWSBedrock,
+			"amazon-bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0"},
+		{"us.anthropic.claude-opus-4-5-20251101-v1:0", AWSBedrock,
+			"amazon-bedrock/anthropic.claude-opus-4-5-20251101-v1:0"},
+		{"apac.amazon.nova-pro-v1:0", AWSBedrock, "amazon-bedrock/amazon.nova-pro-v1:0"},
+		// Only Bedrock strips — a vendor id that happens to start with a
+		// geography-looking token elsewhere must be left alone.
+		{"eu.something", AnthropicDirect, "anthropic/eu.something"},
 	}
 	for _, c := range cases {
 		if got := OpencodeModelID(c.model, c.provider); got != c.want {

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -918,6 +918,74 @@ func TestAgentType_DefaultModelIsOneItRuns(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Retirement. Disabling is the soft delete for a persisted enum: the wire id is
+// in Task documents, so the entry must keep resolving even once nothing offers
+// it. These cases pin BOTH halves — a disabled model that stopped resolving
+// would be a delete with extra steps, and one that kept being offered would be
+// no retirement at all.
+// ---------------------------------------------------------------------------
+
+func TestDisabled_StillResolvesForTasksThatAlreadyHoldIt(t *testing.T) {
+	if !NovaProV1.IsDisabled() {
+		t.Fatal("this test needs a disabled model to be meaningful")
+	}
+	// The reason we disable instead of deleting: a stored Task holds this
+	// string, and every one of these is on the path from that string to a
+	// running agent, or to a rendered row in the UI.
+	m, err := GetModel("nova-pro-v1")
+	if err != nil || m != NovaProV1 {
+		t.Fatalf("GetModel(\"nova-pro-v1\") = %v, %v — a retired model must still parse, or history and in-flight Jobs break", m, err)
+	}
+	if m.DisplayName() == "" || m.DisplayName() == m.String() {
+		t.Errorf("DisplayName() = %q; a retired model must still render as itself", m.DisplayName())
+	}
+	if m.Vendor() != VendorAmazon {
+		t.Errorf("Vendor() = %v, want VendorAmazon", m.Vendor())
+	}
+	// Capability is not offering: the harness can still RUN it, which is what
+	// keeps ProvidersFor non-empty and lets an existing Job spawn.
+	if !Opencode.Supports(m) {
+		t.Error("Opencode.Supports(nova-pro-v1) = false; a retired model must stay runnable for Tasks that already chose it")
+	}
+	if len(ProvidersFor(Opencode, m)) == 0 {
+		t.Error("ProvidersFor returned nothing for a retired model; it would fail at spawn as 'not possible'")
+	}
+	if m.IDFor(AWSBedrock) == "" {
+		t.Error("IDFor returned empty for a retired model")
+	}
+}
+
+func TestDisabled_IsOfferedNowhere(t *testing.T) {
+	for _, h := range AllAgentTypes() {
+		for _, m := range h.Models() {
+			if m.IsDisabled() {
+				t.Errorf("%s.Models() offers retired model %s", h, m)
+			}
+		}
+		// Every tier, since a recommendation is the one path that could hand a
+		// user a retired model they never picked.
+		for _, tr := range []Tier{TierFast, TierBalanced, TierFrontier} {
+			if got := ModelForTier(h, tr); got.IsDisabled() {
+				t.Errorf("ModelForTier(%s, %s) recommends retired model %s", h, tr, got)
+			}
+		}
+		// AllModels is the deliberate exception — it answers capability.
+		if len(h.AllModels()) < len(h.Models()) {
+			t.Errorf("%s.AllModels() is smaller than Models(); it must be the superset", h)
+		}
+	}
+}
+
+// A default that is retired would preselect a model no picker lists.
+func TestDisabled_NoAgentDefaultsToARetiredModel(t *testing.T) {
+	for _, h := range AllAgentTypes() {
+		if h.DefaultModel().IsDisabled() {
+			t.Errorf("%s defaults to retired model %s", h, h.DefaultModel())
+		}
+	}
+}
+
 func TestModelsFor_OffersOnlyWhatTheOrgCanServe(t *testing.T) {
 	bedrockOnly := func(p Provider) bool { return p == AWSBedrock }
 	got := ModelsFor(Opencode, bedrockOnly)
@@ -925,9 +993,15 @@ func TestModelsFor_OffersOnlyWhatTheOrgCanServe(t *testing.T) {
 	for _, m := range got {
 		names[m] = true
 	}
-	// Nova is Bedrock-only, so a Bedrock org must see it.
-	if !names[NovaProV1] {
-		t.Errorf("opencode/Bedrock omits nova-pro-v1; got %v", got)
+	// Qwen3 Coder is Bedrock-only, so a Bedrock org must see it. This was
+	// Nova's job until Nova was retired — which is what the next case checks.
+	if !names[Qwen3Coder480B] {
+		t.Errorf("opencode/Bedrock omits qwen3-coder-480b; got %v", got)
+	}
+	// ...and a RETIRED Bedrock-only model must not appear, however well the org
+	// is credentialed. Being serveable is not being offered.
+	if names[NovaProV1] {
+		t.Errorf("opencode/Bedrock still offers retired nova-pro-v1; got %v", got)
 	}
 	// Claude models are served by Bedrock too.
 	if !names[ClaudeSonnet46] {

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -41,6 +41,30 @@ const (
 	ClaudeSonnet45
 	ClaudeOpus45
 
+	// The current Claude generation. Sonnet 5 is the everyday coding model and
+	// Opus 5 the frontier one; Fable 5 is a SPECIALIST (creative writing and
+	// analysis) that costs twice Opus 5, so it is offered but never resolved
+	// into by tier — Opus 4.8 and Opus 5 both precede it in agentTypeToModels.
+	ClaudeSonnet5
+	ClaudeOpus5
+	ClaudeFable5
+
+	// Bedrock-only models from vendors with no direct provider here. These are
+	// what makes opencode worth having: BYO-model at a fraction of the frontier
+	// price, on credentials the org already holds.
+	//
+	// ⚠️ ALL SEVEN ARE BASE-ID-ONLY ON BEDROCK — no cross-region inference
+	// profile exists for any of them, so discovery finds nothing and their
+	// concrete ids are DECLARED in modelProviderID rather than resolved. That is
+	// the opposite of every model above, where the id is deliberately late-bound.
+	Qwen3Coder480B
+	Qwen3CoderNext
+	DeepSeekV32
+	Glm47
+	Glm5
+	MinimaxM25
+	Grok43
+
 	MaxModel // always add models before MaxModel
 )
 
@@ -57,6 +81,20 @@ var modelToString = map[Model]string{
 	NovaProV1:      "nova-pro-v1",
 	ClaudeSonnet45: "claude-sonnet-4-5",
 	ClaudeOpus45:   "claude-opus-4-5",
+	ClaudeSonnet5:  "claude-sonnet-5",
+	ClaudeOpus5:    "claude-opus-5",
+	ClaudeFable5:   "claude-fable-5",
+	// Logical ids, in the same style as every other entry — NOT the Bedrock
+	// ids. "qwen3-coder-480b", not "qwen.qwen3-coder-480b-a35b-v1:0": the
+	// vendor segment and parameter-count suffix are Bedrock's naming, and
+	// baking them into the wire format would tie a stored Task to one provider.
+	Qwen3Coder480B: "qwen3-coder-480b",
+	Qwen3CoderNext: "qwen3-coder-next",
+	DeepSeekV32:    "deepseek-v3.2",
+	Glm47:          "glm-4.7",
+	Glm5:           "glm-5",
+	MinimaxM25:     "minimax-m2.5",
+	Grok43:         "grok-4.3",
 }
 
 var stringToModel = func() map[string]Model {
@@ -86,18 +124,6 @@ func GetModel(s string) (Model, error) {
 	return 0, fmt.Errorf("unknown model id %q", s)
 }
 
-// modelToBedrockFamily maps a logical model to the Bedrock "family token"
-// shared by every concrete inference profile for it.
-//
-// It deliberately stops at the family. A live run turned up two id shapes in
-// one account — `anthropic.claude-sonnet-5` and
-// `anthropic.claude-sonnet-4-5-20250929-v1:0` — so the version and revision
-// come from discovery, not from here. This map only needs to be right about
-// which family a model belongs to, which changes rarely.
-//
-// Absent entry = not available on Bedrock (the GPT models). Keep in step with
-// modelToProviders: a model listing AWSBedrock as a provider needs a family
-// here, and catalog_test.go enforces exactly that.
 // modelToBedrockProfilePrefix maps a logical model to the VERSION-PINNED
 // prefix shared by every concrete inference profile for that exact model.
 //
@@ -109,8 +135,15 @@ func GetModel(s string) (Model, error) {
 // left to discovery, because those genuinely vary per region and account. The
 // model VERSION is not something to guess at.
 //
-// Absent entry = not available on Bedrock (the GPT models). Kept in step with
-// modelToProviders and enforced by catalog_test.go.
+// An absent entry means one of TWO different things, which is why
+// TestCatalog_BedrockModelsDeclareExactlyOneIDMechanism exists:
+//
+//	not served by Bedrock at all           — the GPT models
+//	served, but with NO inference profile  — declared in modelProviderID
+//
+// The second case is the whole Bedrock-only lineup (Qwen, DeepSeek, GLM,
+// MiniMax, Grok). Nothing to discover means nothing to pin, so their ids are
+// stated outright instead.
 var modelToBedrockProfilePrefix = map[Model]string{
 	ClaudeHaiku45:  "claude-haiku-4-5",
 	ClaudeSonnet46: "claude-sonnet-4-6",
@@ -120,6 +153,13 @@ var modelToBedrockProfilePrefix = map[Model]string{
 	NovaProV1:      "nova-pro-v1",
 	ClaudeSonnet45: "claude-sonnet-4-5",
 	ClaudeOpus45:   "claude-opus-4-5",
+	// The 5-generation prefixes cannot collide with their 4.x siblings under
+	// Contains(): "claude-opus-5" is not a substring of
+	// "claude-opus-4-5-20251101-v1:0", and vice versa. That is the property the
+	// version pinning exists to hold, and the reason these read oddly short.
+	ClaudeSonnet5: "claude-sonnet-5",
+	ClaudeOpus5:   "claude-opus-5",
+	ClaudeFable5:  "claude-fable-5",
 }
 
 // BedrockProfilePrefix returns the version-pinned prefix for a model, or ""
@@ -147,6 +187,14 @@ const (
 	VendorMeta
 	VendorMistral
 	VendorAmazon
+	// Vendors reachable only through Bedrock here — no direct provider exists
+	// for any of them, which is the point: opencode can serve them on the AWS
+	// credential an org already has.
+	VendorQwen
+	VendorDeepSeek
+	VendorZAI
+	VendorMiniMax
+	VendorXAI
 
 	MaxVendor // always add vendors before MaxVendor
 )
@@ -158,6 +206,11 @@ var vendorToString = map[Vendor]string{
 	VendorMeta:      "Meta",
 	VendorMistral:   "Mistral",
 	VendorAmazon:    "Amazon",
+	VendorQwen:      "Qwen",
+	VendorDeepSeek:  "DeepSeek",
+	VendorZAI:       "Z.ai",
+	VendorMiniMax:   "MiniMax",
+	VendorXAI:       "xAI",
 }
 
 func (v Vendor) String() string {
@@ -177,6 +230,16 @@ var modelToVendor = map[Model]Vendor{
 	NovaProV1:      VendorAmazon,
 	ClaudeSonnet45: VendorAnthropic,
 	ClaudeOpus45:   VendorAnthropic,
+	ClaudeSonnet5:  VendorAnthropic,
+	ClaudeOpus5:    VendorAnthropic,
+	ClaudeFable5:   VendorAnthropic,
+	Qwen3Coder480B: VendorQwen,
+	Qwen3CoderNext: VendorQwen,
+	DeepSeekV32:    VendorDeepSeek,
+	Glm47:          VendorZAI,
+	Glm5:           VendorZAI,
+	MinimaxM25:     VendorMiniMax,
+	Grok43:         VendorXAI,
 }
 
 // Vendor returns who makes this model, independent of how it is reached.
@@ -239,16 +302,29 @@ func (v Vendor) OpencodeKeepsBedrockGeography() bool {
 // modelProviderID overrides the id used at a specific provider, for models
 // whose provider-side name differs from our logical one.
 //
-// DELIBERATELY EMPTY. No divergence is currently KNOWN — but that is
-// unverified rather than established, which is the reason this seam exists at
-// all. Our ids are ours: opencode resolves models through its own registry
-// (models.dev), and that registry need not agree with either our names or the
-// vendor API's. Populate an entry the moment a real run shows a mismatch;
-// guessing now would bake in a second unverified assumption.
+// The Bedrock entries here are NOT the same kind of thing as the Anthropic
+// models above them. Those are late-bound on purpose: their concrete ids carry
+// regions, dates and revisions that vary per account, so discovery resolves
+// them and pinning one here would break between AWS revisions. These seven have
+// nothing to discover — no cross-region inference profile exists for any of
+// them, so ListInferenceProfiles returns nothing to match and the id has to be
+// stated.
 //
-// Not for providers that resolve ids at runtime — see
-// Provider.ResolvesModelIDAtRuntime.
-var modelProviderID = map[Model]map[Provider]string{}
+// Taken verbatim from models.dev's amazon-bedrock registry, which is what
+// OPENCODE resolves against — so these must track that registry, not Bedrock's
+// own naming, if the two ever disagree.
+//
+// Nothing else populates this map. A provider whose ids are discovered should
+// not appear here — see Provider.ResolvesModelIDAtRuntime.
+var modelProviderID = map[Model]map[Provider]string{
+	Qwen3Coder480B: {AWSBedrock: "qwen.qwen3-coder-480b-a35b-v1:0"},
+	Qwen3CoderNext: {AWSBedrock: "qwen.qwen3-coder-next"},
+	DeepSeekV32:    {AWSBedrock: "deepseek.v3.2"},
+	Glm47:          {AWSBedrock: "zai.glm-4.7"},
+	Glm5:           {AWSBedrock: "zai.glm-5"},
+	MinimaxM25:     {AWSBedrock: "minimax.minimax-m2.5"},
+	Grok43:         {AWSBedrock: "xai.grok-4.3"},
+}
 
 // IDFor returns the model id to use at a given provider: an override when the
 // provider names the model differently, otherwise our logical id.
@@ -286,6 +362,19 @@ var modelToDisplayName = map[Model]string{
 	NovaProV1:      "Nova Pro",
 	ClaudeSonnet45: "Sonnet 4.5",
 	ClaudeOpus45:   "Opus 4.5",
+	ClaudeSonnet5:  "Sonnet 5",
+	ClaudeOpus5:    "Opus 5",
+	ClaudeFable5:   "Fable 5",
+	// The vendor is rendered separately, so these carry none — a picker shows
+	// "Qwen · Qwen3 Coder 480B" and the second word would otherwise repeat.
+	// The parameter counts stay because they distinguish real variants.
+	Qwen3Coder480B: "Qwen3 Coder 480B",
+	Qwen3CoderNext: "Qwen3 Coder Next",
+	DeepSeekV32:    "V3.2",
+	Glm47:          "GLM-4.7",
+	Glm5:           "GLM-5",
+	MinimaxM25:     "M2.5",
+	Grok43:         "Grok 4.3",
 }
 
 // DisplayName returns the human-facing name, falling back to the wire id so an
@@ -310,6 +399,10 @@ func (m Model) DisplayName() string {
 var legacyModels = map[Model]bool{
 	ClaudeSonnet45: true,
 	ClaudeOpus45:   true,
+	// GLM-5 supersedes it. Kept for the same reason as the 4.5-generation
+	// Claude models: Bedrock model access is granted per account, and an org
+	// with 4.7 enabled and not 5 should still have something to run.
+	Glm47: true,
 }
 
 // IsLegacy reports whether a newer generation of this model exists.
@@ -365,6 +458,29 @@ var modelToTier = map[Model]Tier{
 	Gpt53Codex: TierBalanced,
 	Gpt54:      TierBalanced,
 	NovaProV1:  TierBalanced,
+
+	ClaudeSonnet5: TierBalanced,
+	ClaudeOpus5:   TierFrontier,
+	// Frontier by price and capability, but a SPECIALIST — creative writing and
+	// analysis rather than coding. It never wins a tier resolution because Opus
+	// 4.8 and Opus 5 both precede it in agentTypeToModels, so reaching it takes
+	// an explicit pick. Same treatment as 5.3-codex: listed honestly, not
+	// promoted.
+	ClaudeFable5: TierFrontier,
+
+	// The Bedrock-only lineup sits at balanced, deliberately. These are strong
+	// coding models at roughly a tenth of frontier cost, but ranking them
+	// against Claude would be a claim this catalogue cannot support — none has
+	// been run here yet. Balanced states "a reasonable default choice", which is
+	// defensible; frontier would state "the most capable available", which is
+	// not. Revisit per model once real tasks have run on them.
+	Qwen3Coder480B: TierBalanced,
+	Qwen3CoderNext: TierBalanced,
+	DeepSeekV32:    TierBalanced,
+	Glm47:          TierBalanced,
+	Glm5:           TierBalanced,
+	MinimaxM25:     TierBalanced,
+	Grok43:         TierBalanced,
 }
 
 // Tier returns the model's capability band.

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -403,21 +403,45 @@ var legacyModels = map[Model]bool{
 	// Claude models: Bedrock model access is granted per account, and an org
 	// with 4.7 enabled and not 5 should still have something to run.
 	Glm47: true,
-	// Nova Pro caps OUTPUT at 8k, which is the limit that kept Devstral 2 and
-	// Mistral Large 3 out of this catalogue entirely — a coding agent writing
-	// file edits cannot work in it. Qwen3 Coder 480B is newer, has 65k of
-	// output and costs a quarter as much, so nothing recommends Nova Pro on
-	// merit any more.
-	//
-	// Kept rather than deleted because its wire id is in Task documents
-	// already: removing it would make GetModel fail for those, and a re-run
-	// would pass the logical id through to opencode and fail there. Legacy is
-	// the honest position — offerable, labelled, and last in every picker.
-	NovaProV1: true,
 }
 
 // IsLegacy reports whether a newer generation of this model exists.
 func (m Model) IsLegacy() bool { return legacyModels[m] }
+
+// disabledModels are RETIRED: still known, no longer offered.
+//
+// The axis legacy could not express. Legacy means "offer it, but last" — for a
+// superseded model an org may still need, because Bedrock access is granted per
+// account. Disabled means "stop offering it entirely" while keeping the entry
+// alive, and the difference matters because deleting a Model is not actually
+// available to us: the wire id is in Task documents, so GetModel must keep
+// resolving it or history stops rendering and an in-flight Job stops spawning.
+//
+// So this is the soft delete for a persisted enum. A disabled model:
+//
+//	IS still resolvable      — GetModel, String, DisplayName, Vendor all work
+//	IS NOT offered           — absent from Models(), so pickers and kit's
+//	                           creation policy never see it
+//	IS NOT recommended       — ModelForTier skips it
+//
+// Prefer disabling to deleting, always. Deleting an entry here cannot be
+// undone from the data side: the Tasks holding that id become unreadable.
+var disabledModels = map[Model]bool{
+	// Nova Pro caps OUTPUT at 8k — the limit that kept Devstral 2 and Mistral
+	// Large 3 out of this catalogue entirely, since a coding agent writing file
+	// edits cannot work in it. Qwen3 Coder 480B is newer, has 65k of output and
+	// costs a quarter as much, so nothing recommends Nova Pro on merit. It was
+	// added as the Bedrock smoke test back when it was the only Bedrock model
+	// opencode could reach; there are now fourteen.
+	NovaProV1: true,
+}
+
+// IsDisabled reports whether this model has been retired from the catalogue.
+//
+// Callers that OFFER models must honour it. Callers that RESOLVE or RENDER an
+// already-chosen model must not — that is the entire point of disabling rather
+// than deleting.
+func (m Model) IsDisabled() bool { return disabledModels[m] }
 
 // Tier is how capable a model is, independent of when it shipped.
 //
@@ -505,7 +529,10 @@ func (m Model) Tier() Tier { return modelToTier[m] }
 // catalogue gap, not something the caller should have to handle.
 func ModelForTier(h AgentType, t Tier) Model {
 	var current, legacy Model
-	for _, m := range agentTypeToModels[h] {
+	// h.Models(), not agentTypeToModels — a recommendation must never land on a
+	// retired model. It would be the one path that reintroduces a disabled
+	// model to a user who never chose it.
+	for _, m := range h.Models() {
 		if m.Tier() != t {
 			continue
 		}

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -193,21 +193,29 @@ func (m Model) Vendor() Vendor {
 // only carries one where that profile is the invocable id, and it is starkly
 // split — counted from the registry:
 //
-//	anthropic  11 base + 45 geography-prefixed
-//	meta        5 base +  2 geography-prefixed
-//	amazon      4 base +  0
+//	anthropic  11 base + 45 geography-prefixed   overwhelmingly prefixed
+//	amazon      4 base +  0                      never prefixed
+//	meta        5 base +  2                      MIXED — see below
 //	openai, mistral, qwen, nvidia, google, zai, minimax, writer, xai — base only
 //
 // Amazon is NOT the special case it first appears to be: ten of the fifteen
 // vendors are base-only, so KEEPING the prefix is the exception and this map
 // is the exception list.
 //
+// Meta is deliberately ABSENT despite having two prefixed entries. A
+// vendor-wide "keep" would be wrong for the other five, so Meta's split is
+// per-MODEL and this map cannot express it. Nothing forces the question yet —
+// no Meta model is in the catalogue — and inventing an answer here would bake
+// in a guess that no test could exercise. When a Meta model is added,
+// TestBedrockModelsHaveAConsideredGeographyRule fails and the decision gets
+// made against the registry as it stands then, which may need a per-model
+// override rather than an entry here.
+//
 // An absent vendor means "strip", which is the right default for a new vendor
 // and, when wrong, fails loudly — opencode answers ProviderModelNotFoundError
 // rather than quietly running something else.
 var opencodeBedrockGeographyVendors = map[Vendor]bool{
 	VendorAnthropic: true,
-	VendorMeta:      true,
 }
 
 // OpencodeKeepsBedrockGeography reports whether OPENCODE expects this vendor's

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -403,6 +403,17 @@ var legacyModels = map[Model]bool{
 	// Claude models: Bedrock model access is granted per account, and an org
 	// with 4.7 enabled and not 5 should still have something to run.
 	Glm47: true,
+	// Nova Pro caps OUTPUT at 8k, which is the limit that kept Devstral 2 and
+	// Mistral Large 3 out of this catalogue entirely — a coding agent writing
+	// file edits cannot work in it. Qwen3 Coder 480B is newer, has 65k of
+	// output and costs a quarter as much, so nothing recommends Nova Pro on
+	// merit any more.
+	//
+	// Kept rather than deleted because its wire id is in Task documents
+	// already: removing it would make GetModel fail for those, and a re-run
+	// would pass the logical id through to opencode and fail there. Legacy is
+	// the honest position — offerable, labelled, and last in every picker.
+	NovaProV1: true,
 }
 
 // IsLegacy reports whether a newer generation of this model exists.

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -185,7 +185,7 @@ func (m Model) Vendor() Vendor {
 	return modelToVendor[m]
 }
 
-// bedrockGeographyVendors names the vendors whose Bedrock models opencode
+// opencodeBedrockGeographyVendors names the vendors whose Bedrock models opencode
 // lists UNDER their cross-region geography prefix.
 //
 // This mirrors OPENCODE's registry (models.dev), not Bedrock's. Bedrock
@@ -205,18 +205,27 @@ func (m Model) Vendor() Vendor {
 // An absent vendor means "strip", which is the right default for a new vendor
 // and, when wrong, fails loudly — opencode answers ProviderModelNotFoundError
 // rather than quietly running something else.
-var bedrockGeographyVendors = map[Vendor]bool{
+var opencodeBedrockGeographyVendors = map[Vendor]bool{
 	VendorAnthropic: true,
 	VendorMeta:      true,
 }
 
-// UsesBedrockGeographyPrefix reports whether opencode expects this vendor's
+// OpencodeKeepsBedrockGeography reports whether OPENCODE expects this vendor's
 // Bedrock ids to keep their cross-region prefix.
+//
+// ⚠️ OPENCODE-SPECIFIC, and named so on purpose. This is not a statement about
+// what Bedrock accepts. Bedrock publishes eu.amazon.nova-pro-v1:0 and will
+// serve it — discovery found that id there. Only opencode's registry lacks an
+// entry for it, and only opencode routes through that registry.
+//
+// So this must NEVER be applied to claude-code, which reaches Bedrock directly
+// and correctly uses the prefixed profile id for EVERY vendor, Amazon included.
+// A neutral-sounding name here would invite exactly that mistake.
 //
 // VendorUnknown answers true, so a model outside the catalogue passes through
 // untouched rather than being rewritten on a guess.
-func (v Vendor) UsesBedrockGeographyPrefix() bool {
-	return v == VendorUnknown || bedrockGeographyVendors[v]
+func (v Vendor) OpencodeKeepsBedrockGeography() bool {
+	return v == VendorUnknown || opencodeBedrockGeographyVendors[v]
 }
 
 // modelProviderID overrides the id used at a specific provider, for models

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -185,6 +185,40 @@ func (m Model) Vendor() Vendor {
 	return modelToVendor[m]
 }
 
+// bedrockGeographyVendors names the vendors whose Bedrock models opencode
+// lists UNDER their cross-region geography prefix.
+//
+// This mirrors OPENCODE's registry (models.dev), not Bedrock's. Bedrock
+// publishes a geography-prefixed profile for nearly everything, but models.dev
+// only carries one where that profile is the invocable id, and it is starkly
+// split — counted from the registry:
+//
+//	anthropic  11 base + 45 geography-prefixed
+//	meta        5 base +  2 geography-prefixed
+//	amazon      4 base +  0
+//	openai, mistral, qwen, nvidia, google, zai, minimax, writer, xai — base only
+//
+// Amazon is NOT the special case it first appears to be: ten of the fifteen
+// vendors are base-only, so KEEPING the prefix is the exception and this map
+// is the exception list.
+//
+// An absent vendor means "strip", which is the right default for a new vendor
+// and, when wrong, fails loudly — opencode answers ProviderModelNotFoundError
+// rather than quietly running something else.
+var bedrockGeographyVendors = map[Vendor]bool{
+	VendorAnthropic: true,
+	VendorMeta:      true,
+}
+
+// UsesBedrockGeographyPrefix reports whether opencode expects this vendor's
+// Bedrock ids to keep their cross-region prefix.
+//
+// VendorUnknown answers true, so a model outside the catalogue passes through
+// untouched rather than being rewritten on a guess.
+func (v Vendor) UsesBedrockGeographyPrefix() bool {
+	return v == VendorUnknown || bedrockGeographyVendors[v]
+}
+
 // modelProviderID overrides the id used at a specific provider, for models
 // whose provider-side name differs from our logical one.
 //


### PR DESCRIPTION
opencode rejected a live Nova task with `ProviderModelNotFoundError`: discovery resolved `eu.amazon.nova-pro-v1:0`, and opencode suggested `amazon.nova-pro-v1:0`.

## The rule is opencode's, and it is vendor-shaped

opencode routes Bedrock through its own registry (models.dev), which is asymmetric about the cross-region geography prefix. Counted from the registry:

| vendor | base | geography-prefixed | |
|---|---|---|---|
| `anthropic` | 11 | 45 | keep |
| `meta` | 5 | 2 | keep |
| `amazon` | 4 | 0 | **strip** |
| `openai`, `mistral`, `qwen`, `nvidia`, `google`, `zai`, `minimax`, `writer`, `xai` | — | 0 | **strip** |

A blanket strip — the first version of this PR — would have fixed Nova and **broken Claude on opencode**, since for Anthropic the prefixed id *is* the cross-region inference profile that newer models generally require. The Nova test could never have caught it.

`amazon.` is not the special case it looked like either: ten of fifteen vendors are base-only, so *keeping* is the exception.

## Shape

The rule hangs off the `Vendor` enum, not off string-sniffing the id:

```go
if p == AWSBedrock && !vendor.OpencodeKeepsBedrockGeography() {
    modelID = stripBedrockGeography(modelID)
}
```

Named for opencode deliberately. This is **not** a fact about Bedrock — Bedrock publishes `eu.amazon.nova-pro-v1:0` and serves it. claude-code reaches Bedrock directly and correctly uses the prefixed id for every vendor, so a neutral name would have invited applying it there.

## Guards

- `TestBedrockModelsHaveAConsideredGeographyRule` walks every Bedrock model and fails if its vendor has no recorded decision — so adding a Bedrock-hosted Llama fails at CI, not at spawn on a customer's runner. (Verified non-vacuous: dropping `VendorAmazon` fails on `nova-pro-v1`.)
- `TestOpencodeModelID_FollowsVendorArgNotTheIDText` passes a vendor contradicting the id, proving the argument is load-bearing.
- `TestOpencodeModelID_StripsEveryGeography` covers all six prefixes. A leftover `return` inside the loop meant only `eu.` was ever checked — `us.amazon.nova-pro-v1:0` would have gone through unstripped.

## Merge order

Signature change: the runner needs deployment-io/runner#96 (drafted) in the same cycle.

1. merge this
2. bump drk in runner#96, un-draft, merge, deploy
3. re-run Nova, **and** an opencode + Sonnet 4.5 task — the case a vendor-blind strip would have broken