### PR TITLE
Promote Opus 5 to default, retire Opus 4.8 to legacy

### DIFF
--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -38,13 +38,13 @@ import (
 // point of keeping Model logical — see PLAN_provider_centric_llm_keys.md §3.3
 // and §4.1, where the prefix's second job (disambiguating the harness) is what
 // made stripping it dangerous until AgentType became explicit.
+//
 // ⚠️ ORDER IS LOAD-BEARING and new entries go at the END. ModelForTier walks
 // this list and takes the first non-legacy match, so inserting a model
 // mid-list silently changes what "high complexity" resolves to for every
-// existing Task. Appending cannot: Opus 4.8 stays the frontier answer for
-// claude-code and opencode even with Opus 5 now in the catalogue, and moving
-// that on should be a deliberate edit to modelToTier, not a side effect of
-// adding a model.
+// existing Task. Appending cannot change it on its own — which is the point.
+// Moving the frontier answer on is a deliberate edit to agentTypeToDefaultModel
+// or legacyModels, never a side effect of adding a model.
 var agentTypeToModels = map[AgentType][]Model{
 	ClaudeCode: {ClaudeHaiku45, ClaudeSonnet45, ClaudeSonnet46, ClaudeOpus45, ClaudeOpus48,
 		ClaudeSonnet5, ClaudeOpus5, ClaudeFable5},
@@ -381,7 +381,12 @@ func preferenceRank(p Provider) int {
 // differently for the same agent.
 var agentTypeToDefaultModel = map[AgentType]Model{
 	// Anthropic's documented pick for agentic coding.
-	ClaudeCode: ClaudeOpus48,
+	//
+	// ⚠️ Moving this moves TWO things: what a picker preselects, and what a
+	// high-complexity session resolves to — the default wins its tier outright
+	// in ModelForTier. Change it deliberately, never as a side effect of adding
+	// a model.
+	ClaudeCode: ClaudeOpus5,
 	// OpenAI's recommended default for Codex.
 	Codex: Gpt55,
 	// Balanced, and reuses an org's existing Anthropic credential — so opencode

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -977,6 +977,53 @@ func TestDisabled_IsOfferedNowhere(t *testing.T) {
 	}
 }
 
+// What a session gets when it names no model. Pinned because it is the least
+// visible thing in this package and the most consequential: it is what the
+// Assistant's session→Task conversion uses, so a change here silently moves
+// every Task created without an explicit model.
+//
+// It also had NO test until Opus 5 replaced Opus 4.8 as the default — that
+// change altered what every high-complexity session runs on and the suite
+// stayed green.
+func TestTierResolution_IsPinned(t *testing.T) {
+	cases := []struct {
+		agent AgentType
+		tier  Tier
+		want  Model
+	}{
+		{ClaudeCode, TierFast, ClaudeHaiku45},
+		{ClaudeCode, TierBalanced, ClaudeSonnet46},
+		{ClaudeCode, TierFrontier, ClaudeOpus5},
+		// opencode's default is Sonnet 4.6, so its frontier answer comes from
+		// the first non-legacy frontier model instead — a different code path
+		// reaching the same model, which is why both are pinned.
+		{Opencode, TierFast, ClaudeHaiku45},
+		{Opencode, TierBalanced, ClaudeSonnet46},
+		{Opencode, TierFrontier, ClaudeOpus5},
+	}
+	for _, c := range cases {
+		if got := ModelForTier(c.agent, c.tier); got != c.want {
+			t.Errorf("ModelForTier(%s, %s) = %s, want %s — this moves what every session without an explicit model runs on", c.agent, c.tier, got, c.want)
+		}
+	}
+}
+
+// An agent whose default is legacy is a half-finished migration.
+//
+// Promoting a new default and retiring the old one are a PACKAGE. Doing only
+// the second leaves a picker preselecting a model it also labels superseded and
+// sorts to the bottom of its own list — and ModelForTier hides it, because the
+// default wins its tier before the legacy check runs. Nothing else would catch
+// this.
+func TestDefaultModelIsNeverLegacy(t *testing.T) {
+	for _, h := range AllAgentTypes() {
+		if h.DefaultModel().IsLegacy() {
+			t.Errorf("%s defaults to %s, which is marked legacy — promote a current model or drop the legacy flag; a preselected model must not read as superseded",
+				h, h.DefaultModel())
+		}
+	}
+}
+
 // A default that is retired would preselect a model no picker lists.
 func TestDisabled_NoAgentDefaultsToARetiredModel(t *testing.T) {
 	for _, h := range AllAgentTypes() {

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -399,6 +399,20 @@ func (m Model) DisplayName() string {
 var legacyModels = map[Model]bool{
 	ClaudeSonnet45: true,
 	ClaudeOpus45:   true,
+	// Opus 5 supersedes it, and the two changes are a PACKAGE: this line and
+	// agentTypeToDefaultModel moved together on purpose.
+	//
+	// Either alone is incoherent. Legacy while still the default would label
+	// and sort-last the very model a picker preselects; a new default while 4.8
+	// still read as current would leave two models both presenting as the
+	// frontier choice. ModelForTier hides the first case — the default wins its
+	// tier before the legacy check runs — so it would have been a UI
+	// contradiction with no test to catch it.
+	//
+	// 4.8 keeps earning its place for exactly the reason legacy exists: Bedrock
+	// model access is granted per account, Opus 5 shipped 2026-07-24, and an
+	// org without it enabled still needs a frontier Claude model to run.
+	ClaudeOpus48: true,
 	// GLM-5 supersedes it. Kept for the same reason as the 4.5-generation
 	// Claude models: Bedrock model access is granted per account, and an org
 	// with 4.7 enabled and not 5 should still have something to run.


### PR DESCRIPTION
Requested change: Opus 5 becomes claude-code's default, Opus 4.8 becomes legacy.

## One change, not two

Either half alone is incoherent:

- **legacy while still default** — the picker preselects a model it also labels superseded and sorts to the bottom of its own list. `ModelForTier` *hides* this, because the default wins its tier before the legacy check runs.
- **new default while 4.8 still reads as current** — two models both presenting as the frontier choice.

## What moves

| | before | after |
|---|---|---|
| claude-code default / preselect | Opus 4.8 | **Opus 5** |
| claude-code frontier tier | Opus 4.8 | **Opus 5** |
| opencode frontier tier | Opus 4.8 | **Opus 5** |

Two different code paths reach that: claude-code resolves it as its default, opencode as the first non-legacy frontier model (its own default is Sonnet 4.6, a balanced model). Both are pinned.

Opus 4.8 stays fully offerable, now in the legacy group — which is exactly what legacy is for here: **Bedrock model access is granted per account**, Opus 5 shipped 2026-07-24, and an org without it enabled still needs a frontier Claude model.

## Two tests added, because this passed a green suite

`TestTierResolution_IsPinned` pins all six agent/tier answers. This is the least visible thing in the package and the most consequential — it is what the Assistant's session→Task conversion uses when no model is named ([convertSessionController.go:76](https://github.com/deployment-io/app-server/blob/master/cmd/service/controllers/assistant/sessions/convertSessionController.go#L76)), so moving it silently changes every such Task. It had **no coverage at all** before this.

`TestDefaultModelIsNeverLegacy` catches the half-migration directly.

Verified non-vacuous: reverting the default alone fails both.

## Risk

The real one is **Bedrock account access**. Orgs that have not enabled Opus 5 will have high-complexity sessions resolve to a model they cannot invoke, and we cannot detect per-model access — only whether a provider is configured, so the existing fallback does not catch it. Worth confirming Opus 5 invokes on your account before this deploys. Anthropic Direct and subscription orgs are unaffected.