### PR TITLE
Add token rates keyed by (model, provider)

### DIFF
--- a/enums/llm_provider_enums/pricing.go
+++ b/enums/llm_provider_enums/pricing.go
@@ -1,0 +1,108 @@
+package llm_provider_enums
+
+// Token pricing, keyed by (model, provider).
+//
+// ⚠️ THESE RATES DESCRIBE THE PRESENT, NEVER THE PAST.
+//
+// A rate here is an input to pricing a run AT THE MOMENT IT COMPLETES. The
+// result is then recorded with the run and never recomputed, because vendors
+// change prices and a Task's cost is a fact about when it happened. Deriving a
+// historical cost from this table would silently rewrite every past Task the
+// next time someone edited a number — no migration, no audit trail, and the
+// dashboard quietly disagreeing with the invoice.
+//
+// That is not hypothetical: it is what app-server did before this existed. Its
+// codex estimate ran during response mapping, so the cost of a June run was
+// whatever the table said today.
+//
+// KEYED BY PROVIDER, not by model alone, because the same model costs
+// different amounts depending on the route. Bedrock, Vertex and the gateway
+// providers (Vercel, Cloudflare) each publish their own price for a model
+// whose vendor is someone else entirely — and a gateway's margin is exactly
+// the difference a model-only table cannot express.
+
+// Rate is a model's token pricing at one provider, in USD per million tokens.
+//
+// Three rates rather than two because cached input bills lower than fresh
+// input at every provider that offers it, and an agent re-reading a large
+// repo context is mostly cache hits. Treating them as one rate overstates a
+// long run substantially.
+type Rate struct {
+	// InputPerM prices fresh (non-cached) input tokens.
+	InputPerM float64
+	// CachedPerM prices input served from cache.
+	CachedPerM float64
+	// OutputPerM prices output tokens, reasoning tokens included.
+	OutputPerM float64
+}
+
+// modelProviderRate holds published rates per (model, provider).
+//
+// SPARSE ON PURPOSE. An absent entry means "we cannot price this", which
+// callers must render as an unknown cost rather than as zero — a confidently
+// wrong number is worse than an honest blank.
+//
+// Only the pairs we actually need to price are here. Claude Code and opencode
+// report their own cost, so nothing needs a rate to price them; codex reports
+// token counts alone, which is why its models are the entries below. Add a
+// pair when something has to price a run we cannot otherwise measure.
+//
+// Source: OpenAI's published API pricing, cross-checked against the Codex
+// credit rate card (1 credit = $0.04). Nothing calls a vendor at runtime — a
+// maintainer consults the pricing page by hand when updating this.
+var modelProviderRate = map[Model]map[Provider]Rate{
+	Gpt55:      {OpenAIDirect: {InputPerM: 5.00, CachedPerM: 0.50, OutputPerM: 30.00}},
+	Gpt54:      {OpenAIDirect: {InputPerM: 2.50, CachedPerM: 0.25, OutputPerM: 15.00}},
+	Gpt53Codex: {OpenAIDirect: {InputPerM: 1.75, CachedPerM: 0.175, OutputPerM: 14.00}},
+}
+
+// RateFor returns the published rate for this model at this provider.
+//
+// The bool is the whole point: false means "no published rate for this pair",
+// and the caller must not substitute zero. A subscription has no per-token
+// price at all, so that pair is legitimately absent forever rather than
+// pending.
+func (m Model) RateFor(p Provider) (Rate, bool) {
+	byProvider, ok := modelProviderRate[m]
+	if !ok {
+		return Rate{}, false
+	}
+	r, ok := byProvider[p]
+	return r, ok
+}
+
+// CostUSD prices one run from its token counts.
+//
+// inputTokens is the provider's total input count, which ALREADY INCLUDES the
+// cached subset — that is how both OpenAI and Anthropic report it. The
+// fresh-input portion is therefore (input - cacheRead), and double-counting
+// the cached tokens at the full rate is the obvious way to get this wrong.
+//
+// cacheWriteTokens bills at the fresh-input rate here. Anthropic prices cache
+// writes at a premium over fresh input, so this UNDERSTATES a cache-heavy
+// Claude run — acceptable only because nothing prices Claude from this table
+// today (Claude Code reports its own cost). Give Rate a fourth field before
+// that changes.
+//
+// Negative arithmetic is clamped rather than trusted: a provider reporting
+// cacheRead > input would otherwise produce a negative cost, which reads as a
+// refund.
+func (r Rate) CostUSD(inputTokens, cacheReadTokens, cacheWriteTokens, outputTokens int) float64 {
+	const perMillion = 1_000_000.0
+	fresh := inputTokens - cacheReadTokens
+	if fresh < 0 {
+		fresh = 0
+	}
+	if cacheReadTokens < 0 {
+		cacheReadTokens = 0
+	}
+	if cacheWriteTokens < 0 {
+		cacheWriteTokens = 0
+	}
+	if outputTokens < 0 {
+		outputTokens = 0
+	}
+	return float64(fresh+cacheWriteTokens)/perMillion*r.InputPerM +
+		float64(cacheReadTokens)/perMillion*r.CachedPerM +
+		float64(outputTokens)/perMillion*r.OutputPerM
+}

--- a/enums/llm_provider_enums/pricing_test.go
+++ b/enums/llm_provider_enums/pricing_test.go
@@ -1,0 +1,90 @@
+package llm_provider_enums
+
+import (
+	"math"
+	"testing"
+)
+
+// The published rates, pinned. Not busywork: these numbers turn into figures a
+// customer reads, and a fat-fingered decimal is invisible in review — 0.175 and
+// 1.75 look alike and differ tenfold.
+func TestRateFor_PublishedRatesArePinned(t *testing.T) {
+	cases := map[Model]Rate{
+		Gpt55:      {InputPerM: 5.00, CachedPerM: 0.50, OutputPerM: 30.00},
+		Gpt54:      {InputPerM: 2.50, CachedPerM: 0.25, OutputPerM: 15.00},
+		Gpt53Codex: {InputPerM: 1.75, CachedPerM: 0.175, OutputPerM: 14.00},
+	}
+	for m, want := range cases {
+		got, ok := m.RateFor(OpenAIDirect)
+		if !ok {
+			t.Errorf("%s has no rate at OpenAI Direct", m)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s rate = %+v, want %+v", m, got, want)
+		}
+	}
+	// Cached input must never cost more than fresh input — the discount is the
+	// reason the field exists, and inverting it would overstate every long run.
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		for _, p := range AllProviders() {
+			r, ok := m.RateFor(p)
+			if !ok {
+				continue
+			}
+			if r.CachedPerM > r.InputPerM {
+				t.Errorf("%s at %s: cached %.3f > fresh %.3f", m, p, r.CachedPerM, r.InputPerM)
+			}
+			if r.InputPerM < 0 || r.OutputPerM < 0 || r.CachedPerM < 0 {
+				t.Errorf("%s at %s has a negative rate: %+v", m, p, r)
+			}
+		}
+	}
+}
+
+// Absent must stay distinguishable from zero. A missing rate has to render as
+// an unknown cost; substituting 0.0 tells a customer their run was free.
+func TestRateFor_MissingPairIsNotZero(t *testing.T) {
+	// codex talks only to OpenAI, so this pair is not merely unpriced — it is
+	// unreachable, and must never acquire a rate by accident.
+	if _, ok := Gpt55.RateFor(AWSBedrock); ok {
+		t.Error("Gpt55 reports a Bedrock rate; codex cannot reach Bedrock at all")
+	}
+	// A subscription is a flat fee with no per-token price. This pair is
+	// legitimately absent forever, not pending.
+	if _, ok := ClaudeOpus5.RateFor(AnthropicSubscription); ok {
+		t.Error("a subscription has no per-token rate; pricing one would invent a number")
+	}
+	if r, ok := ClaudeOpus5.RateFor(AnthropicSubscription); r != (Rate{}) || ok {
+		t.Errorf("unpriced pair returned %+v, %v — the zero Rate must never be usable as a price", r, ok)
+	}
+}
+
+func TestRate_CostUSD(t *testing.T) {
+	r := Rate{InputPerM: 5.00, CachedPerM: 0.50, OutputPerM: 30.00}
+
+	// The arithmetic that matters: input ALREADY INCLUDES the cached subset, so
+	// 1M input with 600k cached bills 400k fresh + 600k cached — not 1M + 600k.
+	// Double-counting here is the obvious bug, and it inflates a cache-heavy
+	// run by roughly its whole context.
+	got := r.CostUSD(1_000_000, 600_000, 0, 100_000)
+	want := 0.4*5.00 + 0.6*0.50 + 0.1*30.00 // 2.00 + 0.30 + 3.00
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("CostUSD = %.6f, want %.6f", got, want)
+	}
+
+	// Cache WRITES are extra input, not part of the total, so they add on top.
+	got = r.CostUSD(1_000_000, 600_000, 200_000, 100_000)
+	want += 0.2 * 5.00
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("CostUSD with cache writes = %.6f, want %.6f", got, want)
+	}
+
+	// A provider reporting cacheRead > input must not produce a refund.
+	if got := r.CostUSD(100, 500, 0, 0); got < 0 {
+		t.Errorf("CostUSD = %.6f; a negative cost reads as a refund", got)
+	}
+	if got := r.CostUSD(0, 0, 0, 0); got != 0 {
+		t.Errorf("CostUSD of an empty run = %.6f, want 0", got)
+	}
+}


### PR DESCRIPTION
Input for recording cost at completion instead of deriving it at read time.

## The problem this exists to fix

app-server's codex estimate runs during **response mapping**:

```go
if c := extractAgentCostUSD(output); c != nil { return c }  // claude/opencode: recorded fact
if resolvedAgentType == AgentTypeCodex {
    return estimateCodexCostUSD(model, usage)                // recomputed on every read
}
```

There is no stored cost field, so **every codex cost is recalculated from the current table on every page load**. Edit a rate and a Task from June reports a different cost tomorrow — no migration, no audit trail, and the dashboard quietly disagreeing with the invoice.

So rates here describe the **present, never the past**. They price a run at the moment it completes; the result is recorded with the run and never recomputed. Rate changes then affect only future runs, which is what "the price changed" should mean.

## Keyed by provider

The same model costs different amounts by route. Bedrock, Vertex and the gateway providers (Vercel, Cloudflare) each publish their own price for a model whose vendor is someone else entirely — a gateway's margin is exactly what a model-only table cannot express.

## Sparse on purpose

Absent means "cannot price this", which callers must render as unknown rather than zero — a confidently wrong number is worse than an honest blank. Claude Code and opencode report their own cost, so only the codex models need entries; they move verbatim from app-server's `codexModelPricing`.

`RateFor` returns a bool for exactly this reason. A subscription has no per-token price at all, so that pair is legitimately absent forever rather than pending — there is a test asserting it never acquires one.

## CostUSD folds in the arithmetic that is easy to get wrong

The provider's input count **already includes** the cached subset, so fresh input is `(input - cacheRead)`. Double-counting inflates a cache-heavy run by roughly its whole context. Cache *writes* are extra input on top. Negative arithmetic is clamped, since a negative cost reads as a refund.

Known limitation, stated in the code: cache writes bill at the fresh-input rate, which understates a cache-heavy Claude run because Anthropic prices them at a premium. Harmless while nothing prices Claude from this table — `Rate` needs a fourth field before that changes.

## Next

Runner records the cost at completion; app-server reads the recorded value and keeps the read-time estimate only as a fallback for Jobs that completed before it shipped.