### PR TITLE
Add Novita and OpenRouter as providers

### DIFF
--- a/enums/llm_provider_enums/catalog.go
+++ b/enums/llm_provider_enums/catalog.go
@@ -82,17 +82,30 @@ var modelToProviders = map[Model][]Provider{
 	ClaudeSonnet5:  {AnthropicDirect, AnthropicSubscription, AWSBedrock},
 	ClaudeOpus5:    {AnthropicDirect, AnthropicSubscription, AWSBedrock},
 	ClaudeFable5:   {AnthropicDirect, AnthropicSubscription, AWSBedrock},
-	// Bedrock-ONLY, like Nova and for the same reason: we have no direct
-	// provider for any of these vendors, so AWS is the whole route. An org
-	// without Bedrock configured will not see them at all — ModelsFor filters
-	// on what the org can actually serve.
-	Qwen3Coder480B: {AWSBedrock},
-	Qwen3CoderNext: {AWSBedrock},
-	DeepSeekV32:    {AWSBedrock},
-	Glm47:          {AWSBedrock},
-	Glm5:           {AWSBedrock},
-	MinimaxM25:     {AWSBedrock},
-	Grok43:         {AWSBedrock},
+	// The open-weight lineup. No vendor here has a direct provider of its own,
+	// so these reach us through a cloud, a platform or a gateway.
+	//
+	// Bedrock was the only route until Novita and OpenRouter, and that was a
+	// problem: AWS grants model access PER ACCOUNT PER REGION, so all seven
+	// shipped uninvocable on an account that had not enabled them. Both new
+	// providers need one API key and no per-model step.
+	//
+	// ⚠️ THE THREE ROUTES DO NOT SERVE THE SAME SET, so these lists are not
+	// copy-paste. Verified against models.opencode.ai — the registry opencode
+	// actually resolves against:
+	//
+	//	Novita has no Grok         — a GPU platform cannot host a proprietary
+	//	                             model; only a gateway can route to xAI
+	//	OpenRouter has no 480B     — it carries Qwen3 Coder Next instead
+	//
+	// Which is why both are worth having rather than either alone.
+	Qwen3Coder480B: {AWSBedrock, Novita},
+	Qwen3CoderNext: {AWSBedrock, Novita, OpenRouter},
+	DeepSeekV32:    {AWSBedrock, Novita, OpenRouter},
+	Glm47:          {AWSBedrock, Novita, OpenRouter},
+	Glm5:           {AWSBedrock, Novita, OpenRouter},
+	MinimaxM25:     {AWSBedrock, Novita, OpenRouter},
+	Grok43:         {AWSBedrock, OpenRouter},
 }
 
 // agentProviderCapabilities lists which provider APIs each CLI can talk to.
@@ -128,7 +141,12 @@ var modelToProviders = map[Model][]Provider{
 var agentProviderCapabilities = map[AgentType][]Provider{
 	ClaudeCode: {AnthropicDirect, AnthropicSubscription, AWSBedrock},
 	Codex:      {OpenAIDirect},
-	Opencode:   {AnthropicDirect, AWSBedrock, OpenAIDirect},
+	// Novita and OpenRouter are opencode-only until proven otherwise:
+	// claude-code speaks Anthropic's API and codex authenticates against
+	// api.openai.com. OpenRouter may well expose a compatible surface, but that
+	// is UNVERIFIED — and this table exists because Bedrock hosts OpenAI's
+	// gpt-oss models and codex still cannot reach one.
+	Opencode: {AnthropicDirect, AWSBedrock, OpenAIDirect, Novita, OpenRouter},
 }
 
 // Models returns the models this harness OFFERS — retired ones excluded.
@@ -235,6 +253,11 @@ var opencodeProviderName = map[Provider]string{
 	AnthropicDirect: "anthropic",
 	OpenAIDirect:    "openai",
 	AWSBedrock:      "amazon-bedrock",
+	// The registry ids, not our display names. "novita-ai" reads oddly and is
+	// correct — it is the key in models.opencode.ai, and opencode resolves the
+	// "provider/model" string against exactly that.
+	Novita:     "novita-ai",
+	OpenRouter: "openrouter",
 }
 
 // OpencodeName returns the provider id opencode expects, or "" when opencode

--- a/enums/llm_provider_enums/catalog_test.go
+++ b/enums/llm_provider_enums/catalog_test.go
@@ -562,13 +562,25 @@ func TestIDFor_DefaultsToTheLogicalID(t *testing.T) {
 	// unchanged — this pins the FALLBACK, which is what almost every lookup
 	// hits.
 	//
-	// Deliberately asserts on EVERY provider except that one pair, rather than
-	// listing the models expected to be clean: an override added to a second
-	// provider by accident fails here rather than at spawn.
+	// Deliberately asserts on EVERY pair that has no DECLARED id, rather than
+	// listing the models expected to be clean: an override added by accident
+	// fails here rather than at spawn.
+	//
+	// The exemption is the declared-id set — every open-weight model at Bedrock,
+	// Novita and OpenRouter, each of which names it differently. Those are
+	// covered by the tests above.
+	declared := func(m Model, p Provider) bool {
+		byProvider, ok := modelProviderID[m]
+		if !ok {
+			return false
+		}
+		_, ok = byProvider[p]
+		return ok
+	}
 	for m := ClaudeHaiku45; m < MaxModel; m++ {
 		for _, p := range m.Providers() {
-			if p == AWSBedrock && m.BedrockProfilePrefix() == "" {
-				continue // declared id, covered by the two tests above
+			if declared(m, p) {
+				continue
 			}
 			if got := m.IDFor(p); got != m.String() {
 				t.Errorf("IDFor(%s, %s) = %q, want the logical id %q", m, p, got, m)
@@ -659,6 +671,8 @@ func TestProviderKeys_AreStable(t *testing.T) {
 		GoogleVertex:          "google-vertex",
 		AnthropicSubscription: "anthropic-subscription",
 		OpenAIDirect:          "openai-direct",
+		Novita:                "novita",
+		OpenRouter:            "openrouter",
 	}
 	if len(want) != len(providerKey) {
 		t.Errorf("%d providers have keys, %d pinned — a new slug must be pinned deliberately", len(providerKey), len(want))
@@ -1298,5 +1312,70 @@ func TestAgentType_WireStringsAreStable(t *testing.T) {
 	// existed have no value stored, and agentbox applies the same default.
 	if got, err := ResolveAgentType(""); err != nil || got != ClaudeCode {
 		t.Errorf(`ResolveAgentType("") = %v (%v), want claude-code — legacy Tasks store nothing`, got, err)
+	}
+}
+
+// Declared ids are TRANSCRIBED BY HAND from models.opencode.ai, so their shape
+// is pinned here. Not the strings themselves — that would just restate the map
+// — but the properties a typo breaks, which review does not catch.
+//
+// The Bedrock ids were verified this way after a live run failed on an id that
+// looked right; these three routes name the same model three different ways,
+// down to the vendor segment (zai-org/glm-5 on Novita, z-ai/glm-5 on
+// OpenRouter), so the chance of a transcription error is real.
+func TestCatalog_DeclaredIDsMatchTheRegistryShape(t *testing.T) {
+	// Bedrock uses dots, the opencode-native providers use a slash.
+	separator := map[Provider]string{
+		AWSBedrock: ".",
+		Novita:     "/",
+		OpenRouter: "/",
+	}
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		for p, id := range modelProviderID[m] {
+			sep, known := separator[p]
+			if !known {
+				t.Errorf("%s declares an id at %s, whose id shape is unpinned — add it here deliberately", m, p)
+				continue
+			}
+			if !strings.Contains(id, sep) {
+				t.Errorf("%s at %s = %q: expected a %q separating vendor from model", m, p, id, sep)
+			}
+			if strings.TrimSpace(id) != id || id == "" {
+				t.Errorf("%s at %s = %q: whitespace or empty", m, p, id)
+			}
+			// A declared id must never be the logical one — that is the failure
+			// it exists to prevent, and it reads as correct at a glance.
+			if id == m.String() {
+				t.Errorf("%s at %s declares the LOGICAL id %q; the override is a no-op", m, p, id)
+			}
+		}
+	}
+}
+
+// Every declared (model, provider) pair must appear in modelToProviders, and
+// vice versa for the open-weight models. The two tables are edited separately
+// and a route present in one but not the other is either a model the picker
+// offers but cannot serve, or a dead id nobody reads.
+func TestCatalog_DeclaredIDsAndProviderListsAgree(t *testing.T) {
+	for m := ClaudeHaiku45; m < MaxModel; m++ {
+		serving := map[Provider]bool{}
+		for _, p := range m.Providers() {
+			serving[p] = true
+		}
+		for p := range modelProviderID[m] {
+			if !serving[p] {
+				t.Errorf("%s declares an id at %s but modelToProviders does not list it — a dead id", m, p)
+			}
+		}
+		// The reverse, for the routes that REQUIRE a declared id: an
+		// opencode-native provider has no discovery to fall back on.
+		for _, p := range m.Providers() {
+			if p != Novita && p != OpenRouter {
+				continue
+			}
+			if _, ok := modelProviderID[m][p]; !ok {
+				t.Errorf("%s lists %s but declares no id there; the logical id would reach the provider verbatim", m, p)
+			}
+		}
 	}
 }

--- a/enums/llm_provider_enums/models.go
+++ b/enums/llm_provider_enums/models.go
@@ -316,14 +316,55 @@ func (v Vendor) OpencodeKeepsBedrockGeography() bool {
 //
 // Nothing else populates this map. A provider whose ids are discovered should
 // not appear here — see Provider.ResolvesModelIDAtRuntime.
+// ⚠️ EVERY PROVIDER NAMES THE SAME MODEL DIFFERENTLY, down to the vendor
+// segment — which is why this is keyed on the PAIR and not on the model:
+//
+//	Qwen3 Coder 480B  Bedrock  qwen.qwen3-coder-480b-a35b-v1:0
+//	                  Novita   qwen/qwen3-coder-480b-a35b-instruct
+//	GLM-5             Novita   zai-org/glm-5
+//	                  OpenRouter   z-ai/glm-5
+//
+// A model absent for a provider is absent from that provider's entry in
+// modelToProviders too, and the two must agree. Verified against
+// models.opencode.ai, the registry opencode resolves against, and pinned by
+// TestCatalog_DeclaredIDsMatchTheRegistryShape.
 var modelProviderID = map[Model]map[Provider]string{
-	Qwen3Coder480B: {AWSBedrock: "qwen.qwen3-coder-480b-a35b-v1:0"},
-	Qwen3CoderNext: {AWSBedrock: "qwen.qwen3-coder-next"},
-	DeepSeekV32:    {AWSBedrock: "deepseek.v3.2"},
-	Glm47:          {AWSBedrock: "zai.glm-4.7"},
-	Glm5:           {AWSBedrock: "zai.glm-5"},
-	MinimaxM25:     {AWSBedrock: "minimax.minimax-m2.5"},
-	Grok43:         {AWSBedrock: "xai.grok-4.3"},
+	Qwen3Coder480B: {
+		AWSBedrock: "qwen.qwen3-coder-480b-a35b-v1:0",
+		Novita:     "qwen/qwen3-coder-480b-a35b-instruct",
+		// OpenRouter does not carry the 480B — it serves Coder Next instead.
+	},
+	Qwen3CoderNext: {
+		AWSBedrock: "qwen.qwen3-coder-next",
+		Novita:     "qwen/qwen3-coder-next",
+		OpenRouter: "qwen/qwen3-coder-next",
+	},
+	DeepSeekV32: {
+		AWSBedrock: "deepseek.v3.2",
+		Novita:     "deepseek/deepseek-v3.2",
+		OpenRouter: "deepseek/deepseek-v3.2",
+	},
+	Glm47: {
+		AWSBedrock: "zai.glm-4.7",
+		Novita:     "zai-org/glm-4.7",
+		OpenRouter: "z-ai/glm-4.7",
+	},
+	Glm5: {
+		AWSBedrock: "zai.glm-5",
+		Novita:     "zai-org/glm-5",
+		OpenRouter: "z-ai/glm-5",
+	},
+	MinimaxM25: {
+		AWSBedrock: "minimax.minimax-m2.5",
+		Novita:     "minimax/minimax-m2.5",
+		OpenRouter: "minimax/minimax-m2.5",
+	},
+	Grok43: {
+		AWSBedrock: "xai.grok-4.3",
+		// Novita runs open weights on its own GPUs and cannot host a
+		// proprietary model; only a gateway can route to xAI.
+		OpenRouter: "x-ai/grok-4.3",
+	},
 }
 
 // IDFor returns the model id to use at a given provider: an override when the

--- a/enums/llm_provider_enums/providers.go
+++ b/enums/llm_provider_enums/providers.go
@@ -64,6 +64,29 @@ const (
 	AnthropicSubscription Provider = 4
 	// OpenAIDirect is catalogue-only; see the note above.
 	OpenAIDirect Provider = 5
+	// Novita is an inference PLATFORM: it runs the open-weight models on its
+	// own GPUs, so the relationship is direct and there is no per-model
+	// enablement step. That last part is the point — the Bedrock lineup below
+	// is gated per account per region by AWS, which left seven shipped models
+	// uninvocable on the only Bedrock account we have.
+	//
+	// Chosen on measured data rather than reputation: of the providers serving
+	// our curated open models, it is the only one covering all five, at 99.4%
+	// uptime and the lowest price, quantized to fp8. The platforms every
+	// comparison article recommends cover 1-3 of the five. See
+	// PLAN_NOVITA_OPENROUTER_PROVIDERS.md.
+	Novita Provider = 6
+	// OpenRouter is a GATEWAY: it serves nothing itself and routes to whichever
+	// platform hosts a model. Complementary to Novita rather than redundant —
+	// no single platform is best per model (Qwen3 Coder Next is 65k/fp8 on
+	// Novita against 262k/bf16 elsewhere), and routing per model is exactly
+	// what a gateway buys.
+	//
+	// The key is the CUSTOMER'S, like every other provider here. That is what
+	// makes a gateway unremarkable rather than a privacy question: they chose
+	// it and accepted its terms. It would only become one if we routed through
+	// an account of ours.
+	OpenRouter Provider = 7
 )
 
 // providerToString values are USER-VISIBLE. They are surfaced as
@@ -77,6 +100,8 @@ var providerToString = map[Provider]string{
 	GoogleVertex:          "Google Vertex",
 	AnthropicSubscription: "Claude Subscription",
 	OpenAIDirect:          "OpenAI Direct",
+	Novita:                "Novita",
+	OpenRouter:            "OpenRouter",
 }
 
 func (p Provider) String() string {
@@ -125,7 +150,7 @@ func (p Provider) IsValid() bool {
 // so persisting both would create a pair that can disagree.
 func (p Provider) AuthMode() AuthMode {
 	switch p {
-	case AnthropicDirect, OpenAIDirect:
+	case AnthropicDirect, OpenAIDirect, Novita, OpenRouter:
 		return AuthAPIKey
 	case AWSBedrock, GoogleVertex:
 		return AuthCloudRole
@@ -219,6 +244,12 @@ var providerKey = map[Provider]string{
 	GoogleVertex:          "google-vertex",
 	AnthropicSubscription: "anthropic-subscription",
 	OpenAIDirect:          "openai-direct",
+	// No "-direct" suffix: that suffix distinguishes a vendor's own API from
+	// the other routes to the SAME vendor's models (Bedrock, a subscription).
+	// Neither of these has a sibling route to disambiguate from, so the bare
+	// name is the honest key.
+	Novita:     "novita",
+	OpenRouter: "openrouter",
 }
 
 var keyToProvider = func() map[string]Provider {


### PR DESCRIPTION
Implements [PLAN_NOVITA_OPENROUTER_PROVIDERS.md](https://github.com/deployment-io/plans/blob/master/PLAN_NOVITA_OPENROUTER_PROVIDERS.md).

## Why

The open-weight lineup reaches us only through Bedrock, where AWS grants model access **per account per region** — so all seven shipped models are uninvocable on the only Bedrock account we have. Both new providers need one API key and **no per-model enablement**. This is the unlock for scope already merged, not new scope.

## Chosen on measured data, not reputation

Every "best inference provider" article is a vendor blog. OpenRouter's endpoints API is live traffic, and against the five models we curate it says the recommended platforms **fail on coverage**:

| provider | serves | uptime | quant |
|---|---|---|---|
| **Novita** | **5/5** | 99.4% | fp8 |
| DeepInfra | 3/5 | 96.4% | **fp4** |
| Together | 2/5 | — | — |
| Fireworks | 1/5 | — | — |

Groq and Cerebras win every latency benchmark and carry none of our models.

## The two are complementary, not redundant

```
Novita has no Grok      — a GPU platform cannot host a proprietary model
OpenRouter has no 480B  — it carries Qwen3 Coder Next instead
```

And no single platform is best per model — Qwen3 Coder Next is 65k/fp8 on Novita against 262k on OpenRouter. Routing per model is exactly what a gateway buys.

## Ids are transcribed, so their shape is tested

The three routes name the same model three ways, down to the vendor segment:

```
GLM-5   Bedrock zai.glm-5   Novita zai-org/glm-5   OpenRouter z-ai/glm-5
```

Every id comes from `models.opencode.ai`, the registry opencode actually resolves against — the same verification that caught the Bedrock ids. Two new tests pin the id shape and the agreement between `modelProviderID` and `modelToProviders`, since a route present in one but not the other is either an offer we cannot serve or a dead id.

## opencode-only, deliberately

claude-code speaks Anthropic's API; codex authenticates against `api.openai.com`. OpenRouter may well expose a compatible surface, but that is **unverified** — and `agentProviderCapabilities` exists precisely because Bedrock hosts OpenAI's gpt-oss models and codex still cannot reach one.

## Caught by existing tests

The exhaustive provider-key test flagged both slugs as unpinned. They are `novita` and `openrouter` — no `-direct` suffix, which exists to distinguish a vendor's own API from other routes to the same vendor's models; neither of these has a sibling to disambiguate from.

## Follow-ups, not in this PR

- **agentbox**: `providerHostFromModel` → `api.novita.ai` / `openrouter.ai`, and `opencodeProviderEnvKey` → `NOVITA_API_KEY` / `OPENROUTER_API_KEY`. **Required before either works** — a missing host means the proxy denies egress and every run fails, exactly as a missing `models.opencode.ai` did in v1.9.3.
- app-server and dashboard need nothing: both are `AuthAPIKey`, so the cards and the agent-models endpoint pick them up from the catalogue.